### PR TITLE
Swap individual voice sliders from generic HTML input to Material UI Slider

### DIFF
--- a/src/renderer/Avatar.tsx
+++ b/src/renderer/Avatar.tsx
@@ -11,6 +11,7 @@ import ErrorOutlIne from '@material-ui/icons/ErrorOutlIne';
 // import Tooltip from '@material-ui/core/Tooltip';
 import Tooltip from 'react-tooltip-lite';
 import { SocketConfig } from '../common/ISettings';
+import Slider from '@material-ui/core/Slider';
 
 const useStyles = makeStyles(() => ({
 	canvas: {
@@ -108,26 +109,28 @@ const Avatar: React.FC<AvatarProps> = function ({
 				<div>
 					<b>{player?.name}</b>
 					<div className="slidecontainer" style={{ minWidth: '55px' }}>
-						<input
-							type="range"
-							min="0"
-							max="2"
+						<Slider
 							value={socketConfig?.volume}
-							className="relativeGainSlider"
-							style={{ width: '50px' }}
-							step="any"
+							min={0}
+							max={2}
+							step={.02}
+
+							onChange={(_, newValue: number | number[]) => {
+								if (socketConfig) {
+									socketConfig.volume = newValue as number; 
+								}
+							}}
+
+							valueLabelDisplay={'auto'}
+							valueLabelFormat={(value) => Math.floor(value*100) + '%' }
+
 							onMouseLeave={() => {
 								console.log('onmouseleave');
 								if (onConfigChange) {
 									onConfigChange();
 								}
 							}}
-							onChange={(ev): void => {
-								if (socketConfig) {
-									socketConfig.volume = parseFloat(ev.target.value.substr(0, 6));
-								}
-							}}
-						></input>
+						/>
 					</div>{' '}
 				</div>
 			}


### PR DESCRIPTION
The current player volume adjustment works fine but it does not fit in with all the other settings visually, nor does it have any feedback on how loud you've adjusted someone. By switching to a Material UI Slider we can get both of these with basically no extra code. You can see the effects here: [https://imgur.com/a/ZexNFe9](https://imgur.com/a/ZexNFe9). The label only appears when you hover over the bar and the bar scales with the width of the containing div in the case of a longer name (the current bar was always 50px).

I had implemented voice volumes on default CrewLink myself for my friends but then found out about BetterCrewLink and figured I'd contribute it if I could.