### PR TITLE
Implemented push to mute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bettercrewlink",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "license": "GPL-3.0-or-later",
   "description": "Free, open, Among Us proximity voice chat",
   "repository": {

--- a/src/common/ISettings.d.ts
+++ b/src/common/ISettings.d.ts
@@ -2,7 +2,7 @@ export interface ISettings {
 	alwaysOnTop: boolean;
 	microphone: string;
 	speaker: string;
-	pushToTalk: boolean;
+	pushToTalkMode: number;
 	serverURL: string;
 	pushToTalkShortcut: string;
 	deafenShortcut: string;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,7 +3,7 @@ import Voice from './Voice';
 import Menu from './Menu';
 import { ipcRenderer } from 'electron';
 import { AmongUsState } from '../common/AmongUsState';
-import Settings, { settingsReducer, lobbySettingsReducer } from './settings/Settings';
+import Settings, { settingsReducer, lobbySettingsReducer, pushToTalkOptions } from './settings/Settings';
 import { GameStateContext, SettingsContext, LobbySettingsContext } from './contexts';
 import { ThemeProvider } from '@material-ui/core/styles';
 import {
@@ -120,7 +120,7 @@ export default function App(): JSX.Element {
 		alwaysOnTop: true,
 		microphone: 'Default',
 		speaker: 'Default',
-		pushToTalk: false,
+		pushToTalkMode: pushToTalkOptions.VOICE,
 		serverURL: 'https://crewl.ink',
 		pushToTalkShortcut: 'V',
 		deafenShortcut: 'RControl',

--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -125,6 +125,12 @@ const keys = new Set([
 	'LControl',
 ]);
 
+export enum pushToTalkOptions {
+	VOICE,
+	PUSH_TO_TALK,
+	PUSH_TO_MUTE,
+}
+
 const store = new Store<ISettings>({
 	migrations: {
 		'2.0.6': (store) => {
@@ -153,6 +159,14 @@ const store = new Store<ISettings>({
 		'2.2.0': (store) => {
 			store.set('mobileHost', true);
 		},
+		'2.2.5': (store) => {
+			const pushToTalkValue = store.get('pushToTalk');
+			if (typeof pushToTalkValue === 'boolean') {
+				store.set("pushToTalkMode", pushToTalkValue ? pushToTalkOptions.PUSH_TO_TALK : pushToTalkOptions.VOICE)
+			}
+			// @ts-ignore
+			store.delete('pushToTalk');
+		}
 	},
 	schema: {
 		alwaysOnTop: {
@@ -167,9 +181,9 @@ const store = new Store<ISettings>({
 			type: 'string',
 			default: 'Default',
 		},
-		pushToTalk: {
-			type: 'boolean',
-			default: false,
+		pushToTalkMode: {
+			type: 'number',
+			default: pushToTalkOptions.VOICE,
 		},
 		serverURL: {
 			type: 'string',
@@ -1014,16 +1028,17 @@ const Settings: React.FC<SettingsProps> = function ({ open, onClose }: SettingsP
 				</TextField>
 				{open && <TestSpeakersButton speaker={settings.speaker} />}
 				<RadioGroup
-					value={settings.pushToTalk}
+					value={settings.pushToTalkMode}
 					onChange={(ev) => {
 						setSettings({
 							type: 'setOne',
-							action: ['pushToTalk', ev.target.value === 'true'],
+							action: ['pushToTalkMode', Number(ev.target.value)]
 						});
 					}}
 				>
-					<FormControlLabel label="Voice Activity" value={false} control={<Radio />} />
-					<FormControlLabel label="Push To Talk" value={true} control={<Radio />} />
+					<FormControlLabel label="Voice Activity" value={pushToTalkOptions.VOICE} control={<Radio />} />
+					<FormControlLabel label="Push To Talk" value={pushToTalkOptions.PUSH_TO_TALK} control={<Radio />} />
+					<FormControlLabel label="Push To Mute" value={pushToTalkOptions.PUSH_TO_MUTE} control={<Radio />} />
 				</RadioGroup>
 				<Divider />
 


### PR DESCRIPTION
Added a functionality to push to mute (the reverse of push to talk). Uses the push to talk key shortcut.

I haven't tested receiving/sending voice however based on the voice indicator in the app it works as intended (green light when talking and not pushing key, no light when talking and pushing key).

Addresses feature request #33 

Note: This did require a version update for settings migration, so per https://semver.org/ I updated the minor version as this is new functionality with backwards compatibility.