### PR TITLE
Add reset button to settings

### DIFF
--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -631,6 +631,14 @@ const Settings: React.FC<SettingsProps> = function ({ open, onClose }: SettingsP
 		}
 	};
 
+	const resetDefaults = () => {
+		store.clear();
+		setSettings({
+			type: 'set',
+			action: store.store,
+		});
+	};
+
 	const microphones = devices.filter((d) => d.kind === 'audioinput');
 	const speakers = devices.filter((d) => d.kind === 'audiooutput');
 	const [localLobbySettings, setLocalLobbySettings] = useState(settings.localLobbySettings);
@@ -638,10 +646,11 @@ const Settings: React.FC<SettingsProps> = function ({ open, onClose }: SettingsP
 	useEffect(() => {
 		setLocalLobbySettings(settings.localLobbySettings);
 	}, [settings.localLobbySettings]);
-
+	
 	const isInMenuOrLobby = gameState?.gameState === GameState.LOBBY || gameState?.gameState === GameState.MENU;
 	const canChangeLobbySettings =
 		gameState?.gameState === GameState.MENU || (gameState?.isHost && gameState?.gameState === GameState.LOBBY);
+	const isInMenuOrGameClosed = (gameState.gameState === undefined) || (gameState.gameState === GameState.MENU);
 
 	const [warningDialog, setWarningDialog] = React.useState({ open: false } as IConfirmDialog);
 
@@ -1475,6 +1484,21 @@ const Settings: React.FC<SettingsProps> = function ({ open, onClose }: SettingsP
 							/>
 						</>
 					)}
+				</div>
+				<Divider />
+				<Typography variant="h6">Troubleshooting</Typography>
+				<div>
+					<DisabledTooltip
+						disabled={!isInMenuOrGameClosed}
+						title={"Not available while in lobby"}
+					>
+						<Button
+							disabled={!isInMenuOrGameClosed}
+							variant="contained" 
+							color="secondary"
+							onClick={() => resetDefaults()}
+						>Restore Defaults</Button>
+					</DisabledTooltip>
 				</div>
 				<Alert className={classes.alert} severity="info" style={{ display: unsaved ? undefined : 'none' }}>
 					Exit Settings to apply changes

--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -632,11 +632,24 @@ const Settings: React.FC<SettingsProps> = function ({ open, onClose }: SettingsP
 	};
 
 	const resetDefaults = () => {
-		store.clear();
-		setSettings({
-			type: 'set',
-			action: store.store,
-		});
+		openWarningDialog(
+			'Are you sure?',
+			'This will reset ALL settings to their default values.',
+			() => {
+				store.clear();
+				setSettings({
+					type: 'set',
+					action: store.store,
+				});
+
+				// I'm like 90% sure this isn't necessary but whenever you click the mic/speaker dropdown it is called, so it may be necessary
+				// updateDevices(); 
+
+				// This is necessary for resetting hotkeys properly, the main thread needs to be notified to reset the hooks
+				ipcRenderer.send(IpcHandlerMessages.RESET_KEYHOOKS);
+			},
+			true
+		);
 	};
 
 	const microphones = devices.filter((d) => d.kind === 'audioinput');
@@ -646,7 +659,7 @@ const Settings: React.FC<SettingsProps> = function ({ open, onClose }: SettingsP
 	useEffect(() => {
 		setLocalLobbySettings(settings.localLobbySettings);
 	}, [settings.localLobbySettings]);
-	
+
 	const isInMenuOrLobby = gameState?.gameState === GameState.LOBBY || gameState?.gameState === GameState.MENU;
 	const canChangeLobbySettings =
 		gameState?.gameState === GameState.MENU || (gameState?.isHost && gameState?.gameState === GameState.LOBBY);


### PR DESCRIPTION
Saw this suggestion on Discord, figured it was worth having as a troubleshooting step. It **should** work with all settings. Setting hotkeys has some weirdness to it but I believe I accounted for that properly. There's also a small chance it fails with switching mic/speakers back to default (I don't have the peripherals to test) but the other settings do nothing special so it should work with all of them.

I included a condition so reset can't be triggered in game or in lobby. This aims to prevent possible bugs if the host resets causing lobby settings to change (like voice distance).

This should be tested more before it is included in an official release but from what I've seen it works.

Let me know what you think!