### PR TITLE
Updated links in issue templates to point to bettercrewlink

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,14 +10,14 @@ assignees: ''
 # Pre-Flight Checklist
 Please use this checklist to avoid spamming:
 
-1. [ ] I am not asking a question => use the [Discord](https://discord.gg/9mwuVNA) if you are
+1. [ ] I am not asking a question => use the [Discord](https://discord.gg/qDqTzvj4SH) if you are
 2. [ ] I am using the Steam version of Among Us
-3. [ ] I have tried to use an [alternative voice server](https://status.crewl.ink/)
+3. [ ] I have tried to use an [alternative voice server](https://bettercrewl.ink/)
 4. [ ] I have checked everyone in my lobby is on the same CrewLink server
 5. [ ] I have used `Ctrl+R` on the CrewLink app when I can't hear some people (this is a known issue)
 6. [ ] I have checked that the CrewLink server I'm using is up to date
 7. [ ] I have a screenshot of any errors
-8. [ ] I have checked that someone else has not reported this using the [search bar](https://github.com/ottomated/CrewLink/issues?q=is%3Aissue)
+8. [ ] I have checked that someone else has not reported this using the [search bar](https://github.com/OhMyGuus/BetterCrewLink/issues?q=is%3Aissue)
 
 **Describe the bug**
 <!-- A clear and concise description of what the bug is. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,8 +9,8 @@ assignees: ''
 # Pre-Flight Checklist
 Please use this checklist to avoid spamming:
 
-1. [ ] I am not asking a question => use the [Discord](https://discord.gg/9mwuVNA) if you are
-2. [ ] I have checked that someone else has not suggested this using the [search bar](https://github.com/ottomated/CrewLink/issues?q=is%3Aissue)
+1. [ ] I am not asking a question => use the [Discord](https://discord.gg/qDqTzvj4SH) if you are
+2. [ ] I have checked that someone else has not suggested this using the [search bar](https://github.com/OhMyGuus/BetterCrewLink/issues?q=is%3Aissue)
 3. [ ] My feature request is not one of the **commonly suggested features**:
 - Adjustable voice radius
 - Mobile support

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <br />
 <p align="center">
-  <a href="https://github.com/ottomated/CrewLink">
+  <a href="https://github.com/OhMyGuus/BetterCrewLink">
     <img src="logo.png" alt="Logo" width="80" height="80">
   </a>
   <h3 align="center">BetterCrewLink a Crewlink fork with extra features & better support</h3>


### PR DESCRIPTION
Some of the links in the readme and issue templates pointed to Otto's discord/repo. Just adding some cleanup of them as they were noticed by someone on discord and that person ended up asking in Otto's discord.