### PR TITLE
Support overlay on linux

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@
 import { autoUpdater } from 'electron-updater';
 import { app, BrowserWindow, ipcMain, session } from 'electron';
 import windowStateKeeper from 'electron-window-state';
+import { platform } from 'os';
 import { join as joinPath } from 'path';
 import { format as formatUrl } from 'url';
 import './hook';
@@ -31,6 +32,9 @@ global.mainWindow = null;
 global.overlay = null;
 
 app.commandLine.appendSwitch('disable-pinch');
+if (platform() === 'linux') {
+    app.disableHardwareAcceleration();
+}
 
 function createMainWindow() {
 	const mainWindowState = windowStateKeeper({});


### PR DESCRIPTION
Looking at [this commit on `electron-overlay-window`](https://github.com/SnosMe/electron-overlay-window/commit/d75bf6137c99123d0d46715b336c3c0744603ff0), it appears that disabling hardware acceleration is necessary to support transparent overlay windows.

Before this, the overlay window was completely black and thus blacked out the among screen. I tested the change, and this no longer happens -- the overlay appears to work as desired.