### PR TITLE
Use local name of languague instead of english name

### DIFF
--- a/src/renderer/settings/languages.ts
+++ b/src/renderer/settings/languages.ts
@@ -1,6 +1,6 @@
 
 export default {
-    "fr" : "French", 
+    "fr" : "Français", 
     "en" : "English", 
-    "es" : "Spanish"
+    "es" : "Español"
 }


### PR DESCRIPTION
Translate languages names to their native name instead of english name. More friendly, especially for young players.