### PR TITLE
Temporary fix to allow new player volume changes

### DIFF
--- a/src/renderer/Avatar.tsx
+++ b/src/renderer/Avatar.tsx
@@ -112,7 +112,7 @@ const Avatar: React.FC<AvatarProps> = function ({
 					<b>{player?.name}</b>
 					<div className="slidecontainer" style={{ minWidth: '55px' }}>
 						<Slider
-							value={socketConfig?.volume || 1}
+							value={socketConfig?.volume ?? 1}
 							min={0}
 							max={2}
 							step={0.02}


### PR DESCRIPTION
When a player who has no volume stored in the config file joined a lobby their volume could not be adjusted until BCL was reloaded. Changing `value={socketConfig?.volume || 1}` in the slider to use `??` fixes this and allows for a new player's volume to be adjusted as soon as they join. I'm not 100% sure why this is but I believe it has to do with our store as `onConfigChange()` throws an error with `||` but not `??`.

I'm working on a more robust fix to hopefully allow use of `||` but this should work with no real issues for release.