### PR TITLE
Properly fixed new player volume adjustment

### DIFF
--- a/src/renderer/Avatar.tsx
+++ b/src/renderer/Avatar.tsx
@@ -29,6 +29,12 @@ const useStyles = makeStyles(() => ({
 		padding: 2,
 		zIndex: 10,
 	},
+	relative: {
+		position: 'relative',
+	},
+	slidecontainer: {
+		minWidth: '55px',
+	},
 }));
 
 export interface CanvasProps {
@@ -103,7 +109,7 @@ const Avatar: React.FC<AvatarProps> = function ({
 	if (player.bugged) {
 		icon = <ErrorOutline className={classes.icon} style={{ background: 'red', borderColor: '' }} />;
 	}
-	
+
 	const canvas = <Canvas
 				className={classes.canvas}
 				color={player.colorId}
@@ -116,14 +122,14 @@ const Avatar: React.FC<AvatarProps> = function ({
 				overflow={overflow}
 				usingRadio={isUsingRadio}
 			/>
-			
+
 	if (socketConfig) {
 		return (
 			<Tooltip
 				content={
 					<div>
 						<b>{player.name}</b>
-						<div className="slidecontainer" style={{ minWidth: '55px' }}>
+						<div className={classes.slidecontainer}>
 							<Slider
 								value={socketConfig.volume}
 								min={0}
@@ -149,7 +155,7 @@ const Avatar: React.FC<AvatarProps> = function ({
 		);
 	} else {
 		return (
-			<div style={{position: "relative"}}>
+			<div className={classes.relative}>
 				{canvas}
 				{icon}
 			</div>

--- a/src/renderer/Avatar.tsx
+++ b/src/renderer/Avatar.tsx
@@ -103,39 +103,8 @@ const Avatar: React.FC<AvatarProps> = function ({
 	if (player.bugged) {
 		icon = <ErrorOutline className={classes.icon} style={{ background: 'red', borderColor: '' }} />;
 	}
-
-	return (
-		<Tooltip
-			useHover={!player.isLocal}
-			content={
-				<div>
-					<b>{player?.name}</b>
-					<div className="slidecontainer" style={{ minWidth: '55px' }}>
-						<Slider
-							value={socketConfig?.volume ?? 1}
-							min={0}
-							max={2}
-							step={0.02}
-							onChange={(_, newValue: number | number[]) => {
-								if (socketConfig) {
-									socketConfig.volume = newValue as number;
-								}
-							}}
-							valueLabelDisplay={'auto'}
-							valueLabelFormat={(value) => Math.floor(value * 100) + '%'}
-							onMouseLeave={() => {
-								console.log('onmouseleave');
-								if (onConfigChange) {
-									onConfigChange();
-								}
-							}}
-						/>
-					</div>{' '}
-				</div>
-			}
-			padding={5}
-		>
-			<Canvas
+	
+	const canvas = <Canvas
 				className={classes.canvas}
 				color={player.colorId}
 				hat={showHat === false ? -1 : player.hatId}
@@ -147,9 +116,45 @@ const Avatar: React.FC<AvatarProps> = function ({
 				overflow={overflow}
 				usingRadio={isUsingRadio}
 			/>
-			{icon}
-		</Tooltip>
-	);
+			
+	if (socketConfig) {
+		return (
+			<Tooltip
+				content={
+					<div>
+						<b>{player.name}</b>
+						<div className="slidecontainer" style={{ minWidth: '55px' }}>
+							<Slider
+								value={socketConfig.volume}
+								min={0}
+								max={2}
+								step={0.02}
+								onChange={(_, newValue: number | number[]) => {socketConfig.volume = newValue as number}}
+								valueLabelDisplay={'auto'}
+								valueLabelFormat={(value) => Math.floor(value * 100) + '%'}
+								onMouseLeave={() => {
+									if (onConfigChange) {
+										onConfigChange();
+									}
+								}}
+							/>
+						</div>{' '}
+					</div>
+				}
+				padding={5}
+			>
+				{canvas}
+				{icon}
+			</Tooltip>
+		);
+	} else {
+		return (
+			<div>
+				{canvas}
+				{icon}
+			</div>
+		);
+	}
 };
 
 interface UseCanvasStylesParams {

--- a/src/renderer/Avatar.tsx
+++ b/src/renderer/Avatar.tsx
@@ -149,7 +149,7 @@ const Avatar: React.FC<AvatarProps> = function ({
 		);
 	} else {
 		return (
-			<div>
+			<div style={{position: "relative"}}>
 				{canvas}
 				{icon}
 			</div>

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -1320,7 +1320,10 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 					const peer = playerSocketIdsRef.current[player.clientId];
 					const connected = socketClients[peer]?.clientId === player.clientId || false;
 					const audio = audioConnected[peer];
+					
+					if (!playerConfigs[player.nameHash]) { playerConfigs[player.nameHash] = {volume: 1}; }
 					const socketConfig = playerConfigs[player.nameHash];
+
 					return (
 						<Grid item key={player.id} xs={getPlayersPerRow(otherPlayers.length)}>
 							<Avatar
@@ -1332,7 +1335,9 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 								isUsingRadio={myPlayer?.isImpostor && impostorRadioClientId.current === player.clientId}
 								size={50}
 								socketConfig={socketConfig}
-								onConfigChange={() => store.set(`playerConfigMap.${player.nameHash}`, playerConfigs[player.nameHash])}
+								onConfigChange={() => {
+									store.set(`playerConfigMap.${player.nameHash}`, playerConfigs[player.nameHash]);
+								}}
 							/>
 						</Grid>
 					);

--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -308,10 +308,18 @@ const store = new Store<ISettings>({
 			type: 'boolean',
 			default: true,
 		},
-
 		playerConfigMap: {
 			type: 'object',
 			default: {},
+			additionalProperties: {
+				type: 'object',
+				properties: {
+					volume: {
+						type: 'number',
+						default: 1
+					}
+				}	
+			}
 		},
 		localLobbySettings: {
 			type: 'object',


### PR DESCRIPTION
The issue seemed to stem from the fact that we didn't have a volume config for the players so by creating one we can eliminate a lot of null checks and have the volume work the moment the player appears on the player list.

This does however have the side effect of saving the volume for every player we encounter. If this is an issue we should look into moving the volume config creation to when the Tooltip opens.