### PR TITLE
Removed useless line & unused 'exiledPlayerId' data

### DIFF
--- a/src/main/GameReader.ts
+++ b/src/main/GameReader.ts
@@ -149,11 +149,6 @@ export default class GameReader {
 			const hostId = this.readMemory<number>('uint32', innerNetClient, this.offsets.hostId);
 			const clientId = this.readMemory<number>('uint32', innerNetClient, this.offsets.clientId);
 
-			const exiledPlayerId = this.readMemory<number>(
-				'byte',
-				this.gameAssembly.modBaseAddr,
-				this.offsets.exiledPlayerId
-			);
 			let lightRadius = 1;
 			let comsSabotaged = false;
 			let currentCamera = CameraLocation.NONE;
@@ -175,7 +170,6 @@ export default class GameReader {
 					}
 
 					players.push(player);
-					if (player.id === exiledPlayerId || player.isDead || player.disconnected || player.name === '') continue;
 				}
 				if (localPlayer) {
 					lightRadius = this.readMemory<number>('float', localPlayer.objectPtr, this.offsets.lightRadius, -1);
@@ -374,7 +368,6 @@ export default class GameReader {
 		this.offsets.playerControl_GameOptions[0] = playerControl;
 		this.offsets.palette[0] = palette;
 		this.offsets.meetingHud[0] = meetingHud;
-		this.offsets.exiledPlayerId[1] = meetingHud;
 		this.offsets.allPlayersPtr[0] = gameData;
 		this.offsets.innerNetClient[0] = innerNetClient;
 		this.offsets.shipStatus[0] = shipStatus;

--- a/src/main/offsetStore.ts
+++ b/src/main/offsetStore.ts
@@ -19,7 +19,6 @@ export interface IOffsets {
 	allPlayers: number[];
 	playerCount: number[];
 	playerAddrPtr: number;
-	exiledPlayerId: number[];
 	gameCode: number[];
 	hostId: number[];
 	clientId: number[];
@@ -97,7 +96,6 @@ export default {
 		allPlayers: [0x10],
 		playerCount: [0x18],
 		playerAddrPtr: 0x20,
-		exiledPlayerId: [0xff, 0x21d03e0, 0xb8, 0, 0xe0, 0x10],
 		shipStatus: [0x21d0ce0, 0xb8, 0x0],
 		shipStatus_systems: [0xd0],
 		shipStatus_map: [0x174],
@@ -201,7 +199,6 @@ export default {
 		allPlayers: [0x08],
 		playerCount: [0xC],
 		playerAddrPtr: 0x10,
-		exiledPlayerId: [0xff, 0x1c573a4, 0x5c, 0, 0x94, 0x08],
 		shipStatus: [0x1c57cac, 0x5c, 0x0],
 		shipStatus_systems: [0x8c],
 		shipStatus_map: [0xe4],


### PR DESCRIPTION
Poking around I found line 178 in GameReader as being useless (continue on last line of a loop), after removing it the exiledPlayerId data became flagged as unused and I couldn't find any effects this data has anywhere in the code. If I missed something please let me know but it seems this data is all just unused.