### PR TITLE
Edited device label regex to allow nested parentheses

### DIFF
--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -550,8 +550,8 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 					if (d.deviceId === 'default') {
 						label = t('buttons.default');
 					} else {
-						const match = /(.+?)\)/.exec(d.label);
-						if (match && match[1]) label = match[1] + ')';
+						const match = /.+?\([^(]+\)/.exec(d.label);
+						if (match && match[0]) label = match[0];
 					}
 					return {
 						id: d.deviceId,


### PR DESCRIPTION
Reported via [discord ticket](https://cdn.discordapp.com/attachments/840022336703037450/840024958854889482/unknown.png), devices with labels containing nested parentheses would be cut off early at the first `)`. This change adjusts the regex slightly to allow for a single nested parentheses.

Real world example: `Speakers (Realtek (R) Audio) (9af8:6534)`
Before: `Speakers (Realtek (R)`
With change: `Speakers (Realtek (R) Audio)` (the hex tag is cut off as intended)