### PR TITLE
Added missing hardware_acceleration_warning

### DIFF
--- a/static/locales/en/translation.json
+++ b/static/locales/en/translation.json
@@ -87,6 +87,7 @@
 				"mobilehost": "Mobile Host",
 				"vad_enabled": "VAD Enabled",
 				"hardware_acceleration": "Hardware Acceleration",
+				"hardware_acceleration_warning": "This may cause a loss of performance on some systems.",
 				"vad_enabled_warning": "You won't see who's talking if deactivate.",
 				"echocancellation": "Echo Cancellation",
 				"noiseSuppression": "Noise Suppression",


### PR DESCRIPTION
Small bugfix, reported on discord by SharablePlayz. Feel free to request a different message or put a different one in, I just guessed.

This string is referenced at [Settings.tsx:1536](https://github.com/OhMyGuus/BetterCrewLink/blob/7d9e7a66570ad8ef21bcb2213358a4d1909cdabf/src/renderer/settings/Settings.tsx#L1536)