### PR TITLE
Added version number to splash message

### DIFF
--- a/src/main/GameReader.ts
+++ b/src/main/GameReader.ts
@@ -26,6 +26,14 @@ import { platform } from 'os';
 import fs from 'fs';
 import path from 'path';
 import { AmongusMod, modList } from '../common/PublicLobby';
+import { app } from 'electron';
+
+let appVersion = '';
+if (process.env.NODE_ENV !== 'production') {
+    appVersion = 'DEV';
+} else {
+    appVersion = app.getVersion();
+}
 
 interface ValueType<T> {
 	read(buffer: BufferSource, offset: number): T;
@@ -662,7 +670,7 @@ export default class GameReader {
 
 		this.writeString(
 			shellCodeAddr + 0xd5,
-			'Ping: {0}ms\n<color=#BA68C8>BetterCrewLink</color>\n<size=60%><color=#BA68C8>https://bettercrewlink.app</color></size>'
+			`Ping: {0}ms\n<size=85%><color=#BA68C8>BetterCrewLink v${appVersion}</color></size>\n<size=60%><color=#BA68C8>https://bettercrewlink.app</color></size>`
 		);
 
 		writeBuffer(this.amongUs!.handle, shellCodeAddr, Buffer.from(shellcode));


### PR DESCRIPTION
Changed "BetterCrewLink" to "BetterCrewLink v2.7.5"  in the ping text splash message (and had to lower the size a bit)