### PR TITLE
Added 'support' for TextMeshPro tags in player names

### DIFF
--- a/src/main/GameReader.ts
+++ b/src/main/GameReader.ts
@@ -875,7 +875,8 @@ export default class GameReader {
 			}
 			const length = Math.max(
 				0,
-				Math.min(readMemoryRaw<number>(this.amongUs.handle, address + (this.is_64bit ? 0x10 : 0x8), 'int'), 15)
+				// Math.min(readMemoryRaw<number>(this.amongUs.handle, address + (this.is_64bit ? 0x10 : 0x8), 'int'), 15)
+                readMemoryRaw<number>(this.amongUs.handle, address + (this.is_64bit ? 0x10 : 0x8), 'int')
 			);
 			const buffer = readBuffer(this.amongUs.handle, address + (this.is_64bit ? 0x14 : 0xc), length << 1);
 			if (buffer) {
@@ -993,8 +994,7 @@ export default class GameReader {
 		const x_round = parseFloat(x?.toFixed(4));
 		const y_round = parseFloat(y?.toFixed(4));
 
-		
-		const name = this.readString(data.name);
+		const name = this.readString(data.name).split(/(?:<.*?>)/).join('');
 		const nameHash = this.hashCode(name);
 		const colorId = data.color === this.rainbowColor ? RainbowColorId : data.color;
 		return {

--- a/src/main/GameReader.ts
+++ b/src/main/GameReader.ts
@@ -994,7 +994,7 @@ export default class GameReader {
 		const x_round = parseFloat(x?.toFixed(4));
 		const y_round = parseFloat(y?.toFixed(4));
 
-		const name = this.readString(data.name).split(/(?:<.*?>)/).join('');
+		const name = this.readString(data.name).split(/<.*?>/).join('');
 		const nameHash = this.hashCode(name);
 		const colorId = data.color === this.rainbowColor ? RainbowColorId : data.color;
 		return {


### PR DESCRIPTION
 and in the process fixed a bug(?) in reading a string from memory.

The TextMeshPro change is basically allowing for longer names and cutting out <.*?>.

This requires a serious code review for the change on line 878 allowing longer names. The surrounding function (readString) is called 3 times, once for the player name, once to get the ping string, and once to get the currentServer. I **believe** this should only cause issues if the offsets are wrong and the string length is not where we think it is but I am not positive. I wasn't able to test if the change effects currentServer as that was blank (and is unused from what I can see) regardless of whether the change on 878 was included.