### PR TITLE
Initial support for platform detection & game launch on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"react-i18next": "^9.0.10",
 		"react-tooltip-lite": "^1.12.0",
 		"registry-js": "^1.15.1",
+		"vdf-parser": "^1.2.0",
 		"simple-peer": "^9.11.0",
 		"socket.io-client": "2.4.0",
 		"source-code-pro": "^2.30.2",

--- a/src/common/GamePlatform.ts
+++ b/src/common/GamePlatform.ts
@@ -30,17 +30,17 @@ export interface GamePlatformMap {
 export interface GamePlatformInstance {
 	available: boolean;
 	key: GamePlatform;
-	launchType: PlatformRunType;
-	registryKey: HKEY;
-	registrySubKey: string;
+	launchType?: PlatformRunType;
+	registryKey?: HKEY;
+	registrySubKey?: string;
 	registryFindKey?: string;
-	registryKeyValue: string;
+	registryKeyValue?: string;
 	run: string;
 	exeFile?: string;
 	translateKey: string;
 }
 
-export const DefaultGamePlatforms: GamePlatformMap = {
+export const DefaultWindowsGamePlatforms: GamePlatformMap = {
 	[GamePlatform.STEAM]: {
 		available: false,
 		key: GamePlatform.STEAM,
@@ -74,5 +74,14 @@ export const DefaultGamePlatforms: GamePlatformMap = {
 		exeFile: 'Among Us.exe',
 		translateKey: 'platform.microsoft',
 	},
+}
+
+export const DefaultLinuxGamePlatforms: GamePlatformMap = {
+	[GamePlatform.STEAM]: {
+		available: false,
+		key: GamePlatform.STEAM,
+		run: '/usr/bin/steam steam://rungameid/945360',
+		translateKey: 'platform.steam',
+	}
 };
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -102,18 +102,18 @@ export const initializeIpcHandlers = (): void => {
 				const game_platform = DefaultWindowsGamePlatforms[key];
 				if (game_platform.key === GamePlatform.EPIC || game_platform.key === GamePlatform.STEAM) {
 					// Search registry for the URL Protocol
-					if (enumerateValues(game_platform.registryKey, game_platform.registrySubKey).find(
+					if (enumerateValues(game_platform.registryKey!!, game_platform.registrySubKey!!).find(
 						(value) => value ? value.name === game_platform.registryKeyValue : false
 					)) {
 						game_platform.available = true;
 					}
 				} else if (game_platform.key === GamePlatform.MICROSOFT) {
 					// Search for 'Innersloth.Among Us....' key and grab it
-					const key_found = enumerateKeys(game_platform.registryKey, game_platform.registrySubKey).find(
+					const key_found = enumerateKeys(game_platform.registryKey!!, game_platform.registrySubKey).find(
 						(reg_key) => reg_key.startsWith(game_platform.registryFindKey as string));
 					if (key_found) {
 						// Grab the game path from the above key
-						const value_found = enumerateValues(game_platform.registryKey, game_platform.registrySubKey + '\\' + key_found).find(
+						const value_found = enumerateValues(game_platform.registryKey!!, game_platform.registrySubKey + '\\' + key_found).find(
 							(value) => (value ? value.name === game_platform.registryKeyValue : false)
 						);
 						if (value_found) {
@@ -128,9 +128,10 @@ export const initializeIpcHandlers = (): void => {
 			for (const key in DefaultLinuxGamePlatforms) {
 				const game_platform = DefaultLinuxGamePlatforms[key];
 				if (game_platform.key === GamePlatform.STEAM) {
+					// TODO: Check and support other types of steam installations; Flatpak
 					try {
 						const buff = readFileSync(homedir() + '/.steam/registry.vdf');
-						const steamVdf = parse(buff.toString());
+						const steamVdf = parse(buff.toString()) as {Registry:{HKCU:{Software:{Valve:{Steam:{Apps:object}}}}}};
 						//tries to find Among Us's Steam Id in the .vdf-file
 						if ("945360" in steamVdf["Registry"]["HKCU"]["Software"]["Valve"]["Steam"]["Apps"]) {
 							game_platform.available = true;
@@ -141,6 +142,8 @@ export const initializeIpcHandlers = (): void => {
 				}
 			}
 			return DefaultLinuxGamePlatforms;
+		} else {
+			return DefaultWindowsGamePlatforms;
 		}
 	});
 };

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -2,7 +2,7 @@ import { app, dialog, ipcMain, shell } from 'electron';
 import { platform, homedir } from 'os';
 import { enumerateValues, enumerateKeys } from 'registry-js';
 import { parse } from 'vdf-parser';
-import { DefaultWindowsGamePlatforms, DefaultLinuxGamePlatforms, GamePlatform, PlatformRunType, GamePlatformInstance } from '../common/GamePlatform';
+import { DefaultWindowsGamePlatforms, DefaultLinuxGamePlatforms, GamePlatform, PlatformRunType } from '../common/GamePlatform';
 import spawn from 'cross-spawn';
 import path from 'path';
 import { readFileSync } from 'fs';
@@ -139,8 +139,8 @@ export const initializeIpcHandlers = (): void => {
 						/* empty */
 					}
 				}
-				return DefaultLinuxGamePlatforms;
 			}
+			return DefaultLinuxGamePlatforms;
 		}
 	});
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9826,6 +9826,11 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+vdf-parser@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/vdf-parser/-/vdf-parser-1.2.0.tgz#bd9170e0a6262c8f6b6f91cd0405483a714dba3e"
+  integrity sha512-aPDNRtkNGo5gOcO7SrEkb01IOcvITIndJ5f9mFWs6j4VYaJ+SQMw37R3Wf0eyU0JjBsNYsjrn5LBGxE8r4oeBQ==
+
 verror@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"


### PR DESCRIPTION
Pull request to get platform detection and game launch working for Steam on Linux. This initial commit only works with native Steam installs which uses a registry.vdf file in ~/.steam/ (not Flatpak, e.g.).

The node module [vdf-parser](https://www.npmjs.com/package/vdf-parser) is included to parse the Steam "registry.vdf" found in homedir/.steam on most Linux systems. The vdf-file includes the object Apps, where the Among Us SteamID can be found.

I've also swapped the `DefaultGamePlatforms` constant with `DefaultLinuxGamePlatforms` (for platform() = "linux") and `DefaultWindowsGamePlatforms` (for platform() = "win32"), since Steam is the only supported platform on Linux as of now. It also wouldn't have to loop through and load unsupported platforms. The new `GamePlatformMap` for Linux also omits the registry keys for Windows.

I've confirmed it works with Manjaro, and will check other Linux distributions tomorrow. It also addressed #237

I am pretty new to TypeScript and larger projects in general. The solution I've proposed might be horrible for all i know, but might get the ball rolling. :) 