### PR TITLE
Added platform detection for Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"structron": "^0.2.4",
 		"typeface-varela": "^1.1.13",
 		"valid-url": "^1.0.9",
+		"vdf-parser": "^1.2.0",
 		"webrtc-adapter": "^7.7.0"
 	},
 	"devDependencies": {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -119,9 +119,9 @@ export const initializeIpcHandlers = (): void => {
 			// Add platform to availableGamePlatforms and setup data if platform is available, do nothing otherwise
 			try {
 				const vdfString = fs.readFileSync(homedir() + '/.steam/registry.vdf').toString()
-				const vdfObject = parse(vdfString) as {Registry:{HKCU:{Software:{Valve:{Steam:{Apps:object}}}}}};
-				//tries to find Among Us's Steam Id in the .vdf-file
-				if ("945360" in vdfObject["Registry"]["HKCU"]["Software"]["Valve"]["Steam"]["Apps"]) {
+				const vdfObject = parse(vdfString) as {Registry:{HKCU:{Software:{Valve:{Steam:{Apps:{945360:{installed:number}}}}}}}};
+				//checks if Among Us's listed as installed in the .vdf-file
+				if (vdfObject["Registry"]["HKCU"]["Software"]["Valve"]["Steam"]["Apps"]["945360"]["installed"] == 1) {
 					availableGamePlatforms[GamePlatform.STEAM] = DefaultGamePlatforms[GamePlatform.STEAM];
 				}
 			} catch(e) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9826,6 +9826,11 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+vdf-parser@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/vdf-parser/-/vdf-parser-1.2.0.tgz#bd9170e0a6262c8f6b6f91cd0405483a714dba3e"
+  integrity sha512-aPDNRtkNGo5gOcO7SrEkb01IOcvITIndJ5f9mFWs6j4VYaJ+SQMw37R3Wf0eyU0JjBsNYsjrn5LBGxE8r4oeBQ==
+
 verror@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"


### PR DESCRIPTION
Added platform detection for Linux as discussed in #245

Opening URIs on Linux via openPath didn't work (failed with `Check failed: chdir(current_directory) == 0`). Therefore I swapped to openExternal. The methods described by Electron:

openPath:
> Resolves with a string containing the error message corresponding to the failure if a failure occurred, otherwise "". Open the given file in the desktop's default manner.

openExternal:
> Open the given external protocol URL in the desktop's default manner. (For example, mailto: URLs in the user's default mail agent).

Given these should be URIs when called, it should work on Windows too right? I don't have the means to check as of now.