### PR TITLE
Optimizing settings panel

### DIFF
--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -753,6 +753,8 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 		});
 	}, []);
 
+	if (!open) { return <></> }
+	
 	return (
 		<Box className={classes.root}>
 			<div className={classes.header}>


### PR DESCRIPTION
Currently the settings panel re-renders every cycle, this is a relatively expensive operation. Rendering an empty node when settings aren't open should save on lag. This isn't optimal but it does seem to work. Ideally we should refactor to not render anything when not needed, even when settings are open. Idea credits to Guus.

**Should test if this causes any issues before merging, will try tomorrow and update**

