### PR TITLE
Potential fix to crashing when launched via custom exe

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -32,8 +32,13 @@ export const initializeIpcListeners = (): void => {
 			shell.openExternal(platform.runPath);
 		} else if (platform.launchType === PlatformRunType.EXE) {
 			try {
-				const process = spawn(path.join(platform.runPath, platform.execute[0]), platform.execute.slice(1));
+				const process = spawn(
+					path.join(platform.runPath, platform.execute[0]),
+					platform.execute.slice(1),
+					{ detached: true, stdio: 'ignore' }
+				);
 				process.on('error', error);
+				process.unref();
 			} catch (e) {
 				error();
 			}


### PR DESCRIPTION
Detached the child process and un-referenced it so the processes are completely separate. This seems to resolve a random crash issue but it's hard to know for certain.

See: https://nodejs.org/api/child_process.html#optionsdetached

Closes: #233 