### PR TITLE
Fixed reload and minimize buttons to work properly

### DIFF
--- a/src/main/hook.ts
+++ b/src/main/hook.ts
@@ -114,7 +114,7 @@ ipcMain.handle(IpcHandlerMessages.START_HOOK, async (event) => {
 	}
 });
 
-ipcMain.on('reload', async (lobbybrowser) => {
+ipcMain.on('reload', async (_, lobbybrowser) => {
 	if (!lobbybrowser) {
 		global.mainWindow?.reload();
 	}
@@ -122,7 +122,7 @@ ipcMain.on('reload', async (lobbybrowser) => {
 	//	global.overlay?.reload();
 });
 
-ipcMain.on('minimize', async (lobbybrowser) => {
+ipcMain.on('minimize', async (_, lobbybrowser) => {
 	if (!lobbybrowser) {
 		global.mainWindow?.minimize();
 	}


### PR DESCRIPTION
The syntax for `ipcMain.on` is
```ts
ipcMain.on(channel: string, listener: (event: Electron.IpcMainEvent, ...args: any[]) => void): Electron.IpcMain
```
`lobbyBrowser` was actually the event itself and therefore always not null. Fixed by adding a parameter for the event.