### PR TITLE
Update setting loading to simplify flow and fix launch option being forgot

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,7 +3,7 @@ import Voice from './Voice';
 import Menu from './Menu';
 import { ipcRenderer } from 'electron';
 import { AmongUsState } from '../common/AmongUsState';
-import Settings, { settingsReducer, lobbySettingsReducer, pushToTalkOptions } from './settings/Settings';
+import Settings, { settingsReducer, lobbySettingsReducer } from './settings/Settings';
 import { GameStateContext, SettingsContext, LobbySettingsContext, PlayerColorContext } from './contexts';
 import { ThemeProvider } from '@material-ui/core/styles';
 import {
@@ -35,7 +35,8 @@ import 'typeface-varela/index.css';
 import { DEFAULT_PLAYERCOLORS } from '../main/avatarGenerator';
 import './language/i18n';
 import { withNamespaces } from 'react-i18next';
-import { GamePlatform } from '../common/GamePlatform';
+import { ISettings } from '../common/ISettings';
+import Store from 'electron-store';
 let appVersion = '';
 if (typeof window !== 'undefined' && window.location) {
 	const query = new URLSearchParams(window.location.search.substring(1));
@@ -115,6 +116,9 @@ enum AppState {
 	MENU,
 	VOICE,
 }
+
+const store = new Store<ISettings>();
+
 // @ts-ignore
 export default function App({ t }): JSX.Element {
 	const [state, setState] = useState<AppState>(AppState.MENU);
@@ -128,57 +132,7 @@ export default function App({ t }): JSX.Element {
 	const playerColors = useRef<string[][]>(DEFAULT_PLAYERCOLORS);
 	const overlayInitCount = useRef<number>(0);
 
-	const settings = useReducer(settingsReducer, {
-		language: 'default',
-		alwaysOnTop: true,
-		microphone: 'Default',
-		speaker: 'Default',
-		pushToTalkMode: pushToTalkOptions.VOICE,
-		serverURL: 'https://bettercrewl.ink/',
-		pushToTalkShortcut: 'V',
-		deafenShortcut: 'RControl',
-		muteShortcut: 'RAlt',
-		impostorRadioShortcut: 'F',
-		hideCode: false,
-		natFix: false,
-		mobileHost: true,
-		overlayPosition: 'right',
-		compactOverlay: false,
-		enableOverlay: false,
-		meetingOverlay: false,
-		ghostVolume: 100,
-		masterVolume: 100,
-		microphoneGain: 100,
-		micSensitivity: 0.15,
-		microphoneGainEnabled: false,
-		micSensitivityEnabled: false,
-		vadEnabled: true,
-		hardware_acceleration: true,
-		echoCancellation: true,
-		enableSpatialAudio: true,
-		obsSecret: undefined,
-		obsOverlay: false,
-		noiseSuppression: true,
-		playerConfigMap: {},
-		localLobbySettings: {
-			maxDistance: 5.32,
-			haunting: false,
-			hearImpostorsInVents: false,
-			impostersHearImpostersInvent: false,
-			impostorRadioEnabled: false,
-			commsSabotage: false,
-			deadOnly: false,
-			meetingGhostOnly: false,
-			hearThroughCameras: false,
-			wallsBlockAudio: false,
-			visionHearing: false,
-			publicLobby_on: false,
-			publicLobby_title: '',
-			publicLobby_language: 'en',
-		},
-		launchPlatform: GamePlatform.STEAM,
-		customPlatforms: {},
-	});
+	const settings = useReducer(settingsReducer, store.store);
 	const lobbySettings = useReducer(lobbySettingsReducer, settings[0].localLobbySettings);
 
 	useEffect(() => {

--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -563,16 +563,6 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 	const [lobbySettings, setLobbySettings] = useContext(LobbySettingsContext);
 	const [unsavedCount, setUnsavedCount] = useState(0);
 	const unsaved = unsavedCount > 2;
-	useEffect(() => {
-		setSettings({
-			type: 'set',
-			action: store.store,
-		});
-		setLobbySettings({
-			type: 'set',
-			action: store.get('localLobbySettings'),
-		});
-	}, []);
 
 	useEffect(() => {
 		setUnsavedCount((s) => s + 1);


### PR DESCRIPTION
The chosen launch option was not being remembered, after some investigation the settings are currently being loaded weird.
Current workflow:
1. `Settings.tsx` gets a reference to `Config.json` and creates it if it does not exist (filling w/ defaults)
https://github.com/OhMyGuus/BetterCrewLink/blob/ce8ae6d648ee2934fda1819fd7b352316280f995/src/renderer/settings/Settings.tsx#L140-L481
2. `App.tsx` creates an arbitrary settings object filled with values 
https://github.com/OhMyGuus/BetterCrewLink/blob/ce8ae6d648ee2934fda1819fd7b352316280f995/src/renderer/App.tsx#L131-L181
3. `App.tsx` passes this object as settings via a context
4. `Settings.tsx` gets a reference to the settings context https://github.com/OhMyGuus/BetterCrewLink/blob/ce8ae6d648ee2934fda1819fd7b352316280f995/src/renderer/settings/Settings.tsx#L561
5.  `Settings.tsx` **immediately overwrites the entire context** with the contents of `Config.json` from step 1. https://github.com/OhMyGuus/BetterCrewLink/blob/ce8ae6d648ee2934fda1819fd7b352316280f995/src/renderer/settings/Settings.tsx#L566-L575

Proposed workflow:

1. (unchanged) `Settings.tsx` gets a reference to `Config.json` and creates it if it does not exist (filling w/ defaults)
2. `App.tsx` gets a reference to `Config.json`
3. `App.tsx` passes the settings object via a context
4. (unchanged) `Settings.tsx` gets a reference to the settings context
5. That's it.

The original reason I was looking into this was that the launch button wasn't saving your chosen launch once you closed/reloaded BCL. Using the current solution the settings are momentarily hard-coded which means we can't know what the launch button was (or what the custom launch options were) last time. Since we couldn't know what the launch button was last time it has to be re-set to the default of the first available (steam usually). With these changes the settings flow is much easier to understand and they are not briefly hard-coded on every launch.

Definitely needs to be checked and tested.