### PR TITLE
Refactor settings away from useReducer towards a simpler useState

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,7 +3,8 @@ import Voice from './Voice';
 import Menu from './Menu';
 import { ipcRenderer } from 'electron';
 import { AmongUsState } from '../common/AmongUsState';
-import Settings, { settingsReducer, lobbySettingsReducer, pushToTalkOptions } from './settings/Settings';
+import Settings, { settingsReducer, lobbySettingsReducer } from './settings/Settings';
+import SettingsStore from './settings/SettingsStore';
 import { GameStateContext, SettingsContext, LobbySettingsContext, PlayerColorContext } from './contexts';
 import { ThemeProvider } from '@material-ui/core/styles';
 import {
@@ -35,7 +36,6 @@ import 'typeface-varela/index.css';
 import { DEFAULT_PLAYERCOLORS } from '../main/avatarGenerator';
 import './language/i18n';
 import { withNamespaces } from 'react-i18next';
-import { GamePlatform } from '../common/GamePlatform';
 let appVersion = '';
 if (typeof window !== 'undefined' && window.location) {
 	const query = new URLSearchParams(window.location.search.substring(1));
@@ -128,58 +128,9 @@ export default function App({ t }): JSX.Element {
 	const playerColors = useRef<string[][]>(DEFAULT_PLAYERCOLORS);
 	const overlayInitCount = useRef<number>(0);
 
-	const settings = useReducer(settingsReducer, {
-		language: 'default',
-		alwaysOnTop: true,
-		microphone: 'Default',
-		speaker: 'Default',
-		pushToTalkMode: pushToTalkOptions.VOICE,
-		serverURL: 'https://bettercrewl.ink/',
-		pushToTalkShortcut: 'V',
-		deafenShortcut: 'RControl',
-		muteShortcut: 'RAlt',
-		impostorRadioShortcut: 'F',
-		hideCode: false,
-		natFix: false,
-		mobileHost: true,
-		overlayPosition: 'right',
-		compactOverlay: false,
-		enableOverlay: false,
-		meetingOverlay: false,
-		ghostVolume: 100,
-		masterVolume: 100,
-		microphoneGain: 100,
-		micSensitivity: 0.15,
-		microphoneGainEnabled: false,
-		micSensitivityEnabled: false,
-		vadEnabled: true,
-		hardware_acceleration: true,
-		echoCancellation: true,
-		enableSpatialAudio: true,
-		obsSecret: undefined,
-		obsOverlay: false,
-		noiseSuppression: true,
-		playerConfigMap: {},
-		localLobbySettings: {
-			maxDistance: 5.32,
-			haunting: false,
-			hearImpostorsInVents: false,
-			impostersHearImpostersInvent: false,
-			impostorRadioEnabled: false,
-			commsSabotage: false,
-			deadOnly: false,
-			meetingGhostOnly: false,
-			hearThroughCameras: false,
-			wallsBlockAudio: false,
-			visionHearing: false,
-			publicLobby_on: false,
-			publicLobby_title: '',
-			publicLobby_language: 'en',
-		},
-		launchPlatform: GamePlatform.STEAM,
-		customPlatforms: {},
-	});
-	const lobbySettings = useReducer(lobbySettingsReducer, settings[0].localLobbySettings);
+	// TODO: Move away from a reducer
+	const settings = useReducer(settingsReducer, SettingsStore.store);
+	const lobbySettings = useReducer(lobbySettingsReducer, SettingsStore.store.localLobbySettings);
 
 	useEffect(() => {
 		ipcRenderer.send(IpcMessages.SEND_TO_OVERLAY, IpcOverlayMessages.NOTIFY_PLAYERCOLORS_CHANGED, playerColors.current);

--- a/src/renderer/LobbyBrowser/LobbyBrowser.tsx
+++ b/src/renderer/LobbyBrowser/LobbyBrowser.tsx
@@ -20,6 +20,8 @@ import { PublicLobbyMap, PublicLobby } from '../../common/PublicLobby';
 import { modList } from '../../common/Mods';
 import { GameState } from '../../common/AmongUsState';
 
+
+// TODO: Check: does this really need it's own reference?
 const store = new Store<ISettings>();
 const serverUrl = store.get('serverURL', 'https://bettercrewl.ink/');
 const language = store.get('language', 'en');

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -42,7 +42,7 @@ import Mic from '@material-ui/icons/Mic';
 import MicOff from '@material-ui/icons/MicOff';
 import adapter from 'webrtc-adapter';
 import { VADOptions } from './vad';
-import { pushToTalkOptions } from './settings/Settings';
+import { pushToTalkOptions } from './settings/SettingsStore';
 import { poseCollide } from '../common/ColliderMap';
 
 console.log(adapter.browserDetails.browser);
@@ -217,6 +217,8 @@ radioOnAudio.volume = 0.02;
 // radiobeepAudio2.src = radioBeep2;
 // radiobeepAudio2.volume = 0.2;
 
+
+// TODO: Check: does this really need it's own reference?
 const store = new Store<ISettings>();
 const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceProps) {
 	const [error, setError] = useState('');

--- a/src/renderer/contexts.tsx
+++ b/src/renderer/contexts.tsx
@@ -2,6 +2,8 @@ import React, { createContext } from 'react';
 import { AmongUsState } from '../common/AmongUsState';
 import { ISettings, ILobbySettings } from '../common/ISettings';
 
+
+// TODO: Redo this entire file
 type SettingsContextValue = [
 	ISettings,
 	React.Dispatch<{

--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -1,4 +1,3 @@
-import Store from 'electron-store';
 import React, { ReactChild, useCallback, useContext, useEffect, useReducer, useState } from 'react';
 import { SettingsContext, LobbySettingsContext, GameStateContext } from '../contexts';
 import MicrophoneSoundBar from './MicrophoneSoundBar';
@@ -29,7 +28,7 @@ import languages from '../language/languages';
 import ServerURLInput from './ServerURLInput';
 import MuiDivider from '@material-ui/core/Divider';
 import PublicLobbySettings from './PublicLobbySettings';
-import { GamePlatform } from '../../common/GamePlatform';
+import SettingsStore, { pushToTalkOptions } from './SettingsStore';
 
 interface StyleInput {
 	open: boolean;
@@ -131,361 +130,13 @@ const keys = new Set([
 	'LControl',
 ]);
 
-export enum pushToTalkOptions {
-	VOICE,
-	PUSH_TO_TALK,
-	PUSH_TO_MUTE,
-}
-
-const store = new Store<ISettings>({
-	migrations: {
-		'2.0.6': (store) => {
-			if (
-				store.get('serverURL') === 'http://bettercrewl.ink' ||
-				store.get('serverURL') === 'https://bettercrewlink.app' ||
-				store.get('serverURL') === 'http://bettercrewlink.app' ||
-				store.get('serverURL') === 'https://bettercrewlink.app/' ||
-				store.get('serverURL') === 'http://bettercrewlink.app/' ||
-				store.get('serverURL') === 'https://bettercrewl.ink:6523' ||
-				store.get('serverURL') === 'http://bettercrewl.ink:6523' ||
-				store.get('serverURL') === 'https://crewlink.guus.info' ||
-				store.get('serverURL') === 'http://crewlink.guus.info' ||
-				store.get('serverURL') === 'https://crewlink.guus.ninja' ||
-				store.get('serverURL') === 'http://crewlink.guus.ninja' ||
-				store.get('serverURL') === 'https://github.com/OhMyGuus/BetterCrewLink' ||
-				store.get('serverURL') === 'https://mirror.bettercrewl.ink' ||
-				store.get('serverURL') === 'https://mirror.bettercrewl.ink/' ||
-				store.get('serverURL') === 'https://www.curseforge.com/among-us/all-mods/bettercrewlink-proximity-chat' ||
-				store.get('serverURL') === 'https://matadorprobr.itch.io/bettercrewlink' ||
-				store.get('serverURL') === 'https://gamebanana.com/tools/7079' ||
-				store.get('serverURL') === 'https://web.bettercrewl.ink' ||
-				store.get('serverURL') === 'https://obs.bettercrewlink.app' ||
-				store.get('serverURL') === 'https://discord.gg/qDqTzvj4SH'
-			) {
-				store.set('serverURL', 'https://bettercrewl.ink');
-			}
-		},
-		'2.0.7': (store) => {
-			if (
-				store.get('serverURL') === 'http://bettercrewl.ink' ||
-				store.get('serverURL') === 'https://bettercrewlink.app' ||
-				store.get('serverURL') === 'http://bettercrewlink.app' ||
-				store.get('serverURL') === 'https://bettercrewlink.app/' ||
-				store.get('serverURL') === 'http://bettercrewlink.app/' ||
-				store.get('serverURL') === 'https://bettercrewl.ink:6523' ||
-				store.get('serverURL') === 'http://bettercrewl.ink:6523' ||
-				store.get('serverURL') === 'https://crewlink.guus.info' ||
-				store.get('serverURL') === 'http://crewlink.guus.info' ||
-				store.get('serverURL') === 'https://crewlink.guus.ninja' ||
-				store.get('serverURL') === 'http://crewlink.guus.ninja' ||
-				store.get('serverURL') === 'https://github.com/OhMyGuus/BetterCrewLink' ||
-				store.get('serverURL') === 'https://mirror.bettercrewl.ink' ||
-				store.get('serverURL') === 'https://mirror.bettercrewl.ink/' ||
-				store.get('serverURL') === 'https://www.curseforge.com/among-us/all-mods/bettercrewlink-proximity-chat' ||
-				store.get('serverURL') === 'https://matadorprobr.itch.io/bettercrewlink' ||
-				store.get('serverURL') === 'https://gamebanana.com/tools/7079' ||
-				store.get('serverURL') === 'https://web.bettercrewl.ink' ||
-				store.get('serverURL') === 'https://obs.bettercrewlink.app' ||
-				store.get('serverURL') === 'https://discord.gg/qDqTzvj4SH'
-			) {
-				store.set('serverURL', 'https://bettercrewl.ink');
-			}
-		},
-		'2.1.4': (store) => {
-			store.set('playerConfigMap', {});
-		},
-		'2.2.0': (store) => {
-			store.set('mobileHost', true);
-		},
-		'2.2.5': (store) => {
-			const pushToTalkValue = store.get('pushToTalk');
-			if (typeof pushToTalkValue === 'boolean') {
-				store.set('pushToTalkMode', pushToTalkValue ? pushToTalkOptions.PUSH_TO_TALK : pushToTalkOptions.VOICE);
-			}
-			// @ts-ignore
-			store.delete('pushToTalk');
-		},
-		'2.3.6': (store) => {
-			if ((store.get('serverURL') as string).includes('//crewl.ink')) store.set('serverURL', 'https://bettercrewl.ink');
-		},
-		'2.4.0': (store) => {
-			const currentSensitivity = store.get('micSensitivity') as number;
-			if (currentSensitivity >= 0.3) {
-				store.set('micSensitivity', 0.15);
-				store.set('micSensitivityEnabled', false);
-			}
-		},
-	},
-	schema: {
-		alwaysOnTop: {
-			type: 'boolean',
-			default: false,
-		},
-		language: {
-			type: 'string',
-			default: 'unkown',
-		},
-		microphone: {
-			type: 'string',
-			default: 'Default',
-		},
-		speaker: {
-			type: 'string',
-			default: 'Default',
-		},
-		pushToTalkMode: {
-			type: 'number',
-			default: pushToTalkOptions.VOICE,
-		},
-		serverURL: {
-			type: 'string',
-			default: 'https://bettercrewl.ink',
-			format: 'uri',
-		},
-		pushToTalkShortcut: {
-			type: 'string',
-			default: 'V',
-		},
-		deafenShortcut: {
-			type: 'string',
-			default: 'RControl',
-		},
-		impostorRadioShortcut: {
-			type: 'string',
-			default: 'F',
-		},
-		muteShortcut: {
-			type: 'string',
-			default: 'RAlt',
-		},
-		hideCode: {
-			type: 'boolean',
-			default: false,
-		},
-		compactOverlay: {
-			type: 'boolean',
-			default: false,
-		},
-		overlayPosition: {
-			type: 'string',
-			default: 'right',
-		},
-		meetingOverlay: {
-			type: 'boolean',
-			default: true,
-		},
-		enableOverlay: {
-			type: 'boolean',
-			default: true,
-		},
-		ghostVolume: {
-			type: 'number',
-			default: 100,
-		},
-		masterVolume: {
-			type: 'number',
-			default: 100,
-		},
-		microphoneGain: {
-			type: 'number',
-			default: 100,
-		},
-		microphoneGainEnabled: {
-			type: 'boolean',
-			default: false,
-		},
-		micSensitivity: {
-			type: 'number',
-			default: 0.15,
-		},
-		micSensitivityEnabled: {
-			type: 'boolean',
-			default: false,
-		},
-		natFix: {
-			type: 'boolean',
-			default: false,
-		},
-		mobileHost: {
-			type: 'boolean',
-			default: true,
-		},
-		vadEnabled: {
-			type: 'boolean',
-			default: true,
-		},
-		hardware_acceleration: {
-			type: 'boolean',
-			default: true,
-		},
-		enableSpatialAudio: {
-			type: 'boolean',
-			default: true,
-		},
-		obsSecret: {
-			type: 'string',
-			default: undefined,
-		},
-
-		obsOverlay: {
-			type: 'boolean',
-			default: false,
-		},
-		echoCancellation: {
-			type: 'boolean',
-			default: true,
-		},
-		noiseSuppression: {
-			type: 'boolean',
-			default: true,
-		},
-		playerConfigMap: {
-			type: 'object',
-			default: {},
-			additionalProperties: {
-				type: 'object',
-				properties: {
-					volume: {
-						type: 'number',
-						default: 1,
-					},
-					isMuted: {
-						type: 'boolean',
-						default: false,
-					},
-				},
-			},
-		},
-		localLobbySettings: {
-			type: 'object',
-			properties: {
-				maxDistance: {
-					type: 'number',
-					default: 5.32,
-				},
-				haunting: {
-					type: 'boolean',
-					default: false,
-				},
-				commsSabotage: {
-					type: 'boolean',
-					default: false,
-				},
-				hearImpostorsInVents: {
-					type: 'boolean',
-					default: false,
-				},
-				impostersHearImpostersInvent: {
-					type: 'boolean',
-					default: false,
-				},
-				impostorRadioEnabled: {
-					type: 'boolean',
-					default: false,
-				},
-				deadOnly: {
-					type: 'boolean',
-					default: false,
-				},
-				meetingGhostOnly: {
-					type: 'boolean',
-					default: false,
-				},
-				visionHearing: {
-					type: 'boolean',
-					default: false,
-				},
-				hearThroughCameras: {
-					type: 'boolean',
-					default: false,
-				},
-				wallsBlockAudio: {
-					type: 'boolean',
-					default: false,
-				},
-				publicLobby_on: {
-					type: 'boolean',
-					default: false,
-				},
-				publicLobby_title: {
-					type: 'string',
-					default: '',
-				},
-				publicLobby_language: {
-					type: 'string',
-					default: 'en',
-				},
-				publicLobby_mods: {
-					type: 'string',
-					default: 'NONE',
-				},
-			},
-			default: {
-				maxDistance: 5.32,
-				haunting: false,
-				commsSabotage: false,
-				hearImpostorsInVents: false,
-				hearThroughCameras: false,
-				wallsBlockAudio: false,
-				deadOnly: false,
-				meetingGhostOnly: false,
-				visionHearing: false,
-				publicLobby_on: false,
-				publicLobby_title: '',
-				publicLobby_language: 'en',
-				publicLobby_mods: 'NONE',
-			},
-		},
-		launchPlatform: {
-			type: 'string',
-			default: GamePlatform.STEAM,
-		},
-		customPlatforms: {
-			type: 'object',
-			default: {},
-			additionalProperties: {
-				type: 'object',
-				properties: {
-					default: {
-						type: 'boolean',
-						default: false,
-					},
-					key: {
-						type: 'string',
-						default: '',
-					},
-					launchType: {
-						type: 'string',
-						default: 'EXE',
-					},
-					runPath: {
-						type: 'string',
-						default: '',
-					},
-					execute: {
-						type: 'array',
-						default: [''],
-						items: {
-							type: 'string',
-							default: '',
-						},
-					},
-					translateKey: {
-						type: 'string',
-						default: '',
-					},
-				},
-			},
-		},
-	},
-});
-
 export interface SettingsProps {
 	t: TFunction;
 	open: boolean;
 	onClose: () => void;
 }
 
+// TODO: Remove
 export const settingsReducer = (
 	state: ISettings,
 	action: {
@@ -505,13 +156,14 @@ export const settingsReducer = (
 		v[0] = 'localLobbySettings';
 		v[1] = lobbySettings;
 	}
-	store.set(v[0], v[1]);
+	SettingsStore.set(v[0], v[1]);
 	return {
 		...state,
 		[v[0]]: v[1],
 	};
 };
 
+// TODO: Remove
 export const lobbySettingsReducer = (
 	state: ILobbySettings,
 	action: {
@@ -563,16 +215,6 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 	const [lobbySettings, setLobbySettings] = useContext(LobbySettingsContext);
 	const [unsavedCount, setUnsavedCount] = useState(0);
 	const unsaved = unsavedCount > 2;
-	useEffect(() => {
-		setSettings({
-			type: 'set',
-			action: store.store,
-		});
-		setLobbySettings({
-			type: 'set',
-			action: store.get('localLobbySettings'),
-		});
-	}, []);
 
 	useEffect(() => {
 		setUnsavedCount((s) => s + 1);
@@ -664,10 +306,10 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 	};
 
 	const resetDefaults = () => {
-		store.clear();
+		SettingsStore.clear();
 		setSettings({
 			type: 'set',
-			action: store.store,
+			action: SettingsStore.store,
 		});
 
 		// I'm like 90% sure this isn't necessary but whenever you click the mic/speaker dropdown it is called, so it may be necessary

--- a/src/renderer/settings/SettingsStore.tsx
+++ b/src/renderer/settings/SettingsStore.tsx
@@ -1,0 +1,354 @@
+import Store from 'electron-store';
+import { GamePlatform } from '../../common/GamePlatform';
+import { ISettings } from '../../common/ISettings';
+
+export enum pushToTalkOptions {
+	VOICE,
+	PUSH_TO_TALK,
+	PUSH_TO_MUTE,
+}
+
+export const SettingsStore = new Store<ISettings>({
+	migrations: {
+		'2.0.6': (store) => {
+			if (
+				store.get('serverURL') === 'http://bettercrewl.ink' ||
+				store.get('serverURL') === 'https://bettercrewlink.app' ||
+				store.get('serverURL') === 'http://bettercrewlink.app' ||
+				store.get('serverURL') === 'https://bettercrewlink.app/' ||
+				store.get('serverURL') === 'http://bettercrewlink.app/' ||
+				store.get('serverURL') === 'https://bettercrewl.ink:6523' ||
+				store.get('serverURL') === 'http://bettercrewl.ink:6523' ||
+				store.get('serverURL') === 'https://crewlink.guus.info' ||
+				store.get('serverURL') === 'http://crewlink.guus.info' ||
+				store.get('serverURL') === 'https://crewlink.guus.ninja' ||
+				store.get('serverURL') === 'http://crewlink.guus.ninja' ||
+				store.get('serverURL') === 'https://github.com/OhMyGuus/BetterCrewLink' ||
+				store.get('serverURL') === 'https://mirror.bettercrewl.ink' ||
+				store.get('serverURL') === 'https://mirror.bettercrewl.ink/' ||
+				store.get('serverURL') === 'https://www.curseforge.com/among-us/all-mods/bettercrewlink-proximity-chat' ||
+				store.get('serverURL') === 'https://matadorprobr.itch.io/bettercrewlink' ||
+				store.get('serverURL') === 'https://gamebanana.com/tools/7079' ||
+				store.get('serverURL') === 'https://web.bettercrewl.ink' ||
+				store.get('serverURL') === 'https://obs.bettercrewlink.app' ||
+				store.get('serverURL') === 'https://discord.gg/qDqTzvj4SH'
+			) {
+				store.set('serverURL', 'https://bettercrewl.ink');
+			}
+		},
+		'2.0.7': (store) => {
+			if (
+				store.get('serverURL') === 'http://bettercrewl.ink' ||
+				store.get('serverURL') === 'https://bettercrewlink.app' ||
+				store.get('serverURL') === 'http://bettercrewlink.app' ||
+				store.get('serverURL') === 'https://bettercrewlink.app/' ||
+				store.get('serverURL') === 'http://bettercrewlink.app/' ||
+				store.get('serverURL') === 'https://bettercrewl.ink:6523' ||
+				store.get('serverURL') === 'http://bettercrewl.ink:6523' ||
+				store.get('serverURL') === 'https://crewlink.guus.info' ||
+				store.get('serverURL') === 'http://crewlink.guus.info' ||
+				store.get('serverURL') === 'https://crewlink.guus.ninja' ||
+				store.get('serverURL') === 'http://crewlink.guus.ninja' ||
+				store.get('serverURL') === 'https://github.com/OhMyGuus/BetterCrewLink' ||
+				store.get('serverURL') === 'https://mirror.bettercrewl.ink' ||
+				store.get('serverURL') === 'https://mirror.bettercrewl.ink/' ||
+				store.get('serverURL') === 'https://www.curseforge.com/among-us/all-mods/bettercrewlink-proximity-chat' ||
+				store.get('serverURL') === 'https://matadorprobr.itch.io/bettercrewlink' ||
+				store.get('serverURL') === 'https://gamebanana.com/tools/7079' ||
+				store.get('serverURL') === 'https://web.bettercrewl.ink' ||
+				store.get('serverURL') === 'https://obs.bettercrewlink.app' ||
+				store.get('serverURL') === 'https://discord.gg/qDqTzvj4SH'
+			) {
+				store.set('serverURL', 'https://bettercrewl.ink');
+			}
+		},
+		'2.1.4': (store) => {
+			store.set('playerConfigMap', {});
+		},
+		'2.2.0': (store) => {
+			store.set('mobileHost', true);
+		},
+		'2.2.5': (store) => {
+			const pushToTalkValue = store.get('pushToTalk');
+			if (typeof pushToTalkValue === 'boolean') {
+				store.set('pushToTalkMode', pushToTalkValue ? pushToTalkOptions.PUSH_TO_TALK : pushToTalkOptions.VOICE);
+			}
+			// @ts-ignore
+			store.delete('pushToTalk');
+		},
+		'2.3.6': (store) => {
+			if ((store.get('serverURL') as string).includes('//crewl.ink')) store.set('serverURL', 'https://bettercrewl.ink');
+		},
+		'2.4.0': (store) => {
+			const currentSensitivity = store.get('micSensitivity') as number;
+			if (currentSensitivity >= 0.3) {
+				store.set('micSensitivity', 0.15);
+				store.set('micSensitivityEnabled', false);
+			}
+		},
+	},
+	schema: {
+		alwaysOnTop: {
+			type: 'boolean',
+			default: false,
+		},
+		language: {
+			type: 'string',
+			default: 'unkown',
+		},
+		microphone: {
+			type: 'string',
+			default: 'Default',
+		},
+		speaker: {
+			type: 'string',
+			default: 'Default',
+		},
+		pushToTalkMode: {
+			type: 'number',
+			default: pushToTalkOptions.VOICE,
+		},
+		serverURL: {
+			type: 'string',
+			default: 'https://bettercrewl.ink',
+			format: 'uri',
+		},
+		pushToTalkShortcut: {
+			type: 'string',
+			default: 'V',
+		},
+		deafenShortcut: {
+			type: 'string',
+			default: 'RControl',
+		},
+		impostorRadioShortcut: {
+			type: 'string',
+			default: 'F',
+		},
+		muteShortcut: {
+			type: 'string',
+			default: 'RAlt',
+		},
+		hideCode: {
+			type: 'boolean',
+			default: false,
+		},
+		compactOverlay: {
+			type: 'boolean',
+			default: false,
+		},
+		overlayPosition: {
+			type: 'string',
+			default: 'right',
+		},
+		meetingOverlay: {
+			type: 'boolean',
+			default: true,
+		},
+		enableOverlay: {
+			type: 'boolean',
+			default: true,
+		},
+		ghostVolume: {
+			type: 'number',
+			default: 100,
+		},
+		masterVolume: {
+			type: 'number',
+			default: 100,
+		},
+		microphoneGain: {
+			type: 'number',
+			default: 100,
+		},
+		microphoneGainEnabled: {
+			type: 'boolean',
+			default: false,
+		},
+		micSensitivity: {
+			type: 'number',
+			default: 0.15,
+		},
+		micSensitivityEnabled: {
+			type: 'boolean',
+			default: false,
+		},
+		natFix: {
+			type: 'boolean',
+			default: false,
+		},
+		mobileHost: {
+			type: 'boolean',
+			default: true,
+		},
+		vadEnabled: {
+			type: 'boolean',
+			default: true,
+		},
+		hardware_acceleration: {
+			type: 'boolean',
+			default: true,
+		},
+		enableSpatialAudio: {
+			type: 'boolean',
+			default: true,
+		},
+		obsSecret: {
+			type: 'string',
+			default: undefined,
+		},
+
+		obsOverlay: {
+			type: 'boolean',
+			default: false,
+		},
+		echoCancellation: {
+			type: 'boolean',
+			default: true,
+		},
+		noiseSuppression: {
+			type: 'boolean',
+			default: true,
+		},
+		playerConfigMap: {
+			type: 'object',
+			default: {},
+			additionalProperties: {
+				type: 'object',
+				properties: {
+					volume: {
+						type: 'number',
+						default: 1,
+					},
+					isMuted: {
+						type: 'boolean',
+						default: false,
+					},
+				},
+			},
+		},
+		localLobbySettings: {
+			type: 'object',
+			properties: {
+				maxDistance: {
+					type: 'number',
+					default: 5.32,
+				},
+				haunting: {
+					type: 'boolean',
+					default: false,
+				},
+				commsSabotage: {
+					type: 'boolean',
+					default: false,
+				},
+				hearImpostorsInVents: {
+					type: 'boolean',
+					default: false,
+				},
+				impostersHearImpostersInvent: {
+					type: 'boolean',
+					default: false,
+				},
+				impostorRadioEnabled: {
+					type: 'boolean',
+					default: false,
+				},
+				deadOnly: {
+					type: 'boolean',
+					default: false,
+				},
+				meetingGhostOnly: {
+					type: 'boolean',
+					default: false,
+				},
+				visionHearing: {
+					type: 'boolean',
+					default: false,
+				},
+				hearThroughCameras: {
+					type: 'boolean',
+					default: false,
+				},
+				wallsBlockAudio: {
+					type: 'boolean',
+					default: false,
+				},
+				publicLobby_on: {
+					type: 'boolean',
+					default: false,
+				},
+				publicLobby_title: {
+					type: 'string',
+					default: '',
+				},
+				publicLobby_language: {
+					type: 'string',
+					default: 'en',
+				},
+				publicLobby_mods: {
+					type: 'string',
+					default: 'NONE',
+				},
+			},
+			default: {
+				maxDistance: 5.32,
+				haunting: false,
+				commsSabotage: false,
+				hearImpostorsInVents: false,
+				hearThroughCameras: false,
+				wallsBlockAudio: false,
+				deadOnly: false,
+				meetingGhostOnly: false,
+				visionHearing: false,
+				publicLobby_on: false,
+				publicLobby_title: '',
+				publicLobby_language: 'en',
+				publicLobby_mods: 'NONE',
+			},
+		},
+		launchPlatform: {
+			type: 'string',
+			default: GamePlatform.STEAM,
+		},
+		customPlatforms: {
+			type: 'object',
+			default: {},
+			additionalProperties: {
+				type: 'object',
+				properties: {
+					default: {
+						type: 'boolean',
+						default: false,
+					},
+					key: {
+						type: 'string',
+						default: '',
+					},
+					launchType: {
+						type: 'string',
+						default: 'EXE',
+					},
+					runPath: {
+						type: 'string',
+						default: '',
+					},
+					execute: {
+						type: 'array',
+						default: [''],
+						items: {
+							type: 'string',
+							default: '',
+						},
+					},
+					translateKey: {
+						type: 'string',
+						default: '',
+					},
+				},
+			},
+		},
+	},
+});
+
+export default SettingsStore;


### PR DESCRIPTION
Settings are done in an overly-complicated way. This PR is to track the progress of moving them over to a much simpler and elegant solution.

Todo:
- [ ] `App.tsx` move from a reducer to a normal state
- [ ] `contexts.tsx` redo file to allow for a normal state
- [ ] `Voice.tsx` check if we really need a unique store reference
- [ ] `LobbyBrowser.tsx` check if we really need a unique store reference
- [ ] `Settings.tsx` everything