### PR TITLE
Refactor settings away from useReducer towards a simpler useState

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"eslint-plugin-react": "^7.21.5",
 		"prettier": "^2.2.1",
 		"prettier-eslint": "^12.0.0",
-		"typescript": "^4.0.3",
+		"typescript": "^4.1",
 		"webpack": "~4.42.1",
 		"webpack-dev-server": "^3.11.0"
 	},

--- a/src/common/ISettings.d.ts
+++ b/src/common/ISettings.d.ts
@@ -33,6 +33,7 @@ export interface ISettings {
 	oldSampleDebug: boolean;
 
 	enableSpatialAudio: boolean;
+	oldSampleDebug: boolean;
 	playerConfigMap: playerConfigMap;
 	obsOverlay: boolean;
 	obsSecret: string | undefined;

--- a/src/main/GameReader.ts
+++ b/src/main/GameReader.ts
@@ -105,10 +105,10 @@ export default class GameReader {
 					break;
 				} catch (e) {
 					console.log('ERROR:', e);
-					if (processOpen && e.toString() === 'Error: unable to find process') {
+					if (processOpen && String(e) === 'Error: unable to find process') {
 						error = Errors.OPEN_AS_ADMINISTRATOR;
 					} else {
-						error = e.toString();
+						error = String(e);
 					}
 					this.amongUs = null;
 				}
@@ -154,7 +154,7 @@ export default class GameReader {
 				await this.checkProcessOpen();
 			} catch (e) {
 				this.checkProcessDelay = 0
-				return e.toString();
+				return String(e);
 			}
 		}
 		if (

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -202,10 +202,9 @@ export default function App({ t }): JSX.Element {
 	}, [gameState]);
 
 	useEffect(() => {
-		console.log(playerColors.current);
+		// console.log(playerColors.current);
 		ipcRenderer.send(IpcMessages.SEND_TO_OVERLAY, IpcOverlayMessages.NOTIFY_PLAYERCOLORS_CHANGED, playerColors.current);
 		ipcRenderer.send(IpcMessages.SEND_TO_OVERLAY, IpcOverlayMessages.NOTIFY_SETTINGS_CHANGED, SettingsStore.store);
-		console.log("Didn't work");
 	}, [settings]);
 
 	let page;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -131,7 +131,7 @@ export default function App({ t }): JSX.Element {
 
 	const [settings, setSettings] = useState(SettingsStore.store);
 	SettingsStore.onDidAnyChange((newValue, _) => {setSettings(newValue as ISettings)})
-	const [hostLobbySettings] = useState(settings.localLobbySettings);
+	const [hostLobbySettings, setHostLobbySettings] = useState(settings.localLobbySettings);
 
 	useEffect(() => {
 		ipcRenderer.send(IpcMessages.SEND_TO_OVERLAY, IpcOverlayMessages.NOTIFY_PLAYERCOLORS_CHANGED, playerColors.current);
@@ -219,7 +219,7 @@ export default function App({ t }): JSX.Element {
 	return (
 		<PlayerColorContext.Provider value={playerColors.current}>
 			<GameStateContext.Provider value={gameState}>
-				<HostSettingsContext.Provider value={hostLobbySettings}>
+				<HostSettingsContext.Provider value={[hostLobbySettings, setHostLobbySettings]}>
 					<SettingsContext.Provider value={[settings, setSetting, setLobbySetting]}>
 						<ThemeProvider theme={theme}>
 							<TitleBar settingsOpen={settingsOpen} setSettingsOpen={setSettingsOpen} />

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -130,8 +130,10 @@ export default function App({ t }): JSX.Element {
 	const overlayInitCount = useRef<number>(0);
 
 	const [settings, setSettings] = useState(SettingsStore.store);
-	SettingsStore.onDidAnyChange((newValue, _) => {setSettings(newValue as ISettings)})
 	const [hostLobbySettings, setHostLobbySettings] = useState(settings.localLobbySettings);
+	useEffect(() =>{
+		SettingsStore.onDidAnyChange((newValue, _) => {setSettings(newValue as ISettings)});
+	}, []);
 
 	useEffect(() => {
 		ipcRenderer.send(IpcMessages.SEND_TO_OVERLAY, IpcOverlayMessages.NOTIFY_PLAYERCOLORS_CHANGED, playerColors.current);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,7 +3,8 @@ import Voice from './Voice';
 import Menu from './Menu';
 import { ipcRenderer } from 'electron';
 import { AmongUsState } from '../common/AmongUsState';
-import Settings, { settingsReducer, lobbySettingsReducer, pushToTalkOptions } from './settings/Settings';
+import Settings, { settingsReducer, lobbySettingsReducer } from './settings/Settings';
+import SettingsStore from './settings/SettingsStore';
 import { GameStateContext, SettingsContext, LobbySettingsContext, PlayerColorContext } from './contexts';
 import { ThemeProvider } from '@material-ui/core/styles';
 import {
@@ -35,7 +36,6 @@ import 'typeface-varela/index.css';
 import { DEFAULT_PLAYERCOLORS } from '../main/avatarGenerator';
 import './language/i18n';
 import { withNamespaces } from 'react-i18next';
-import { GamePlatform } from '../common/GamePlatform';
 let appVersion = '';
 if (typeof window !== 'undefined' && window.location) {
 	const query = new URLSearchParams(window.location.search.substring(1));
@@ -128,59 +128,9 @@ export default function App({ t }): JSX.Element {
 	const playerColors = useRef<string[][]>(DEFAULT_PLAYERCOLORS);
 	const overlayInitCount = useRef<number>(0);
 
-	const settings = useReducer(settingsReducer, {
-		language: 'default',
-		alwaysOnTop: true,
-		microphone: 'Default',
-		speaker: 'Default',
-		pushToTalkMode: pushToTalkOptions.VOICE,
-		serverURL: 'https://bettercrewl.ink/',
-		pushToTalkShortcut: 'V',
-		deafenShortcut: 'RControl',
-		muteShortcut: 'RAlt',
-		impostorRadioShortcut: 'F',
-		hideCode: false,
-		natFix: false,
-		mobileHost: true,
-		overlayPosition: 'right',
-		compactOverlay: false,
-		enableOverlay: false,
-		meetingOverlay: false,
-		ghostVolume: 100,
-		masterVolume: 100,
-		microphoneGain: 100,
-		micSensitivity: 0.15,
-		microphoneGainEnabled: false,
-		micSensitivityEnabled: false,
-		vadEnabled: true,
-		hardware_acceleration: true,
-		echoCancellation: true,
-		enableSpatialAudio: true,
-		obsSecret: undefined,
-		obsOverlay: false,
-		noiseSuppression: true,
-		oldSampleDebug: false,
-		playerConfigMap: {},
-		localLobbySettings: {
-			maxDistance: 5.32,
-			haunting: false,
-			hearImpostorsInVents: false,
-			impostersHearImpostersInvent: false,
-			impostorRadioEnabled: false,
-			commsSabotage: false,
-			deadOnly: false,
-			meetingGhostOnly: false,
-			hearThroughCameras: false,
-			wallsBlockAudio: false,
-			visionHearing: false,
-			publicLobby_on: false,
-			publicLobby_title: '',
-			publicLobby_language: 'en',
-		},
-		launchPlatform: GamePlatform.STEAM,
-		customPlatforms: {},
-	});
-	const lobbySettings = useReducer(lobbySettingsReducer, settings[0].localLobbySettings);
+	// TODO: Move away from a reducer
+	const settings = useReducer(settingsReducer, SettingsStore.store);
+	const lobbySettings = useReducer(lobbySettingsReducer, SettingsStore.store.localLobbySettings);
 
 	useEffect(() => {
 		ipcRenderer.send(IpcMessages.SEND_TO_OVERLAY, IpcOverlayMessages.NOTIFY_PLAYERCOLORS_CHANGED, playerColors.current);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,9 +3,9 @@ import Voice from './Voice';
 import Menu from './Menu';
 import { ipcRenderer } from 'electron';
 import { AmongUsState } from '../common/AmongUsState';
-import Settings, { /*settingsReducer, lobbySettingsReducer*/ } from './settings/Settings';
+import Settings from './settings/Settings';
 import SettingsStore, { setSetting, setLobbySetting} from './settings/SettingsStore';
-import { GameStateContext, SettingsContext, /*LobbySettingsContext,*/ PlayerColorContext } from './contexts';
+import { GameStateContext, SettingsContext, PlayerColorContext, HostSettingsContext } from './contexts';
 import { ThemeProvider } from '@material-ui/core/styles';
 import {
 	AutoUpdaterState,
@@ -131,6 +131,7 @@ export default function App({ t }): JSX.Element {
 
 	const [settings, setSettings] = useState(SettingsStore.store);
 	SettingsStore.onDidAnyChange((newValue, _) => {setSettings(newValue as ISettings)})
+	const [hostLobbySettings] = useState(settings.localLobbySettings);
 
 	useEffect(() => {
 		ipcRenderer.send(IpcMessages.SEND_TO_OVERLAY, IpcOverlayMessages.NOTIFY_PLAYERCOLORS_CHANGED, playerColors.current);
@@ -218,7 +219,7 @@ export default function App({ t }): JSX.Element {
 	return (
 		<PlayerColorContext.Provider value={playerColors.current}>
 			<GameStateContext.Provider value={gameState}>
-				{/* <LobbySettingsContext.Provider value={lobbySettings}> */}
+				<HostSettingsContext.Provider value={hostLobbySettings}>
 					<SettingsContext.Provider value={[settings, setSetting, setLobbySetting]}>
 						<ThemeProvider theme={theme}>
 							<TitleBar settingsOpen={settingsOpen} setSettingsOpen={setSettingsOpen} />
@@ -274,7 +275,7 @@ export default function App({ t }): JSX.Element {
 							{page}
 						</ThemeProvider>
 					</SettingsContext.Provider>
-				{/* </LobbySettingsContext.Provider> */}
+				</HostSettingsContext.Provider>
 			</GameStateContext.Provider>
 		</PlayerColorContext.Provider>
 	);

--- a/src/renderer/LaunchButton.tsx
+++ b/src/renderer/LaunchButton.tsx
@@ -89,10 +89,7 @@ const LaunchButton: React.FC<LauncherProps> = function ({ t }: LauncherProps) {
 		if (!launchPlatforms) return;
 		if (!launchPlatforms[settings.launchPlatform]) {
 			for (const key in launchPlatforms) {
-				setSettings({
-					type: 'setOne',
-					action: ['launchPlatform', key],
-				});
+				setSettings('launchPlatform', key);
 				break;
 			}
 		}
@@ -105,10 +102,7 @@ const LaunchButton: React.FC<LauncherProps> = function ({ t }: LauncherProps) {
 				<MenuItem
 					key={platformName}
 					onClick={() => {
-						setSettings({
-							type: 'setOne',
-							action: ['launchPlatform', platform.key],
-						});
+						setSettings('launchPlatform', platform.key);
 						setDropdownOpen(false);
 					}}
 					onContextMenu={() => {

--- a/src/renderer/LobbyBrowser/LobbyBrowser.tsx
+++ b/src/renderer/LobbyBrowser/LobbyBrowser.tsx
@@ -11,20 +11,16 @@ import Button from '@material-ui/core/Button';
 import { ipcRenderer } from 'electron';
 import { IpcHandlerMessages } from '../../common/ipc-messages';
 import io from 'socket.io-client';
-import Store from 'electron-store';
-import { ISettings } from '../../common/ISettings';
 import i18next from 'i18next';
 import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
 import languages from '../language/languages';
 import { PublicLobbyMap, PublicLobby } from '../../common/PublicLobby';
 import { modList } from '../../common/Mods';
 import { GameState } from '../../common/AmongUsState';
+import SettingsStore from '../settings/SettingsStore';
 
-
-// TODO: Check: does this really need it's own reference?
-const store = new Store<ISettings>();
-const serverUrl = store.get('serverURL', 'https://bettercrewl.ink/');
-const language = store.get('language', 'en');
+const serverUrl = SettingsStore.get('serverURL', 'https://bettercrewl.ink/');
+const language = SettingsStore.get('language', 'en');
 i18next.changeLanguage(language);
 
 const StyledTableCell = withStyles((theme) => ({

--- a/src/renderer/LobbyBrowser/LobbyBrowser.tsx
+++ b/src/renderer/LobbyBrowser/LobbyBrowser.tsx
@@ -20,6 +20,8 @@ import { PublicLobbyMap, PublicLobby } from '../../common/PublicLobby';
 import { modList } from '../../common/Mods';
 import { GameState } from '../../common/AmongUsState';
 
+
+// TODO: Check: does this really need it's own reference?
 const store = new Store<ISettings>();
 const serverUrl = store.get('serverURL', 'https://bettercrewl.ink/');
 const language = store.get('language', 'en');

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -42,7 +42,7 @@ import Mic from '@material-ui/icons/Mic';
 import MicOff from '@material-ui/icons/MicOff';
 import adapter from 'webrtc-adapter';
 import { VADOptions } from './vad';
-import { pushToTalkOptions, setSetting } from './settings/SettingsStore';
+import { pushToTalkOptions } from './settings/SettingsStore';
 import { poseCollide } from '../common/ColliderMap';
 
 console.log(adapter.browserDetails.browser);
@@ -222,7 +222,7 @@ radioOnAudio.volume = 0.02;
 // const store = new Store<ISettings>();
 const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceProps) {
 	const [error, setError] = useState('');
-	const [settings, _setSettings] = useContext(SettingsContext);
+	const [settings, setSetting] = useContext(SettingsContext);
 
 	const settingsRef = useRef<ISettings>(settings);
 	const [lobbySettings, setHostLobbySettings] = useContext(HostSettingsContext);

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -42,7 +42,7 @@ import Mic from '@material-ui/icons/Mic';
 import MicOff from '@material-ui/icons/MicOff';
 import adapter from 'webrtc-adapter';
 import { VADOptions } from './vad';
-import { pushToTalkOptions } from './settings/Settings';
+import { pushToTalkOptions } from './settings/SettingsStore';
 import { poseCollide } from '../common/ColliderMap';
 
 console.log(adapter.browserDetails.browser);
@@ -217,6 +217,8 @@ radioOnAudio.volume = 0.02;
 // radiobeepAudio2.src = radioBeep2;
 // radiobeepAudio2.volume = 0.2;
 
+
+// TODO: Check: does this really need it's own reference?
 const store = new Store<ISettings>();
 const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceProps) {
 	const [error, setError] = useState('');

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import io, { Socket } from 'socket.io-client';
 import Avatar from './Avatar';
-import { GameStateContext, LobbySettingsContext, PlayerColorContext, SettingsContext } from './contexts';
+import { GameStateContext, /*LobbySettingsContext,*/ PlayerColorContext, SettingsContext } from './contexts';
 import {
 	AmongUsState,
 	GameState,
@@ -222,10 +222,11 @@ radioOnAudio.volume = 0.02;
 const store = new Store<ISettings>();
 const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceProps) {
 	const [error, setError] = useState('');
-	const [settings] = useContext(SettingsContext);
+	const [settings, _setSettings, setLobbySettings] = useContext(SettingsContext);
 
 	const settingsRef = useRef<ISettings>(settings);
-	const [lobbySettings, setLobbySettings] = useContext(LobbySettingsContext);
+	// const [lobbySettings, setLobbySettings] = useContext(LobbySettingsContext);
+	const lobbySettings = settings.localLobbySettings;
 	const lobbySettingsRef = useRef(lobbySettings);
 	const maxDistanceRef = useRef(2);
 	const gameState = useContext(GameStateContext);
@@ -552,10 +553,11 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 			}
 		});
 
-		setLobbySettings({
-			type: 'set',
-			action: settings.localLobbySettings,
-		});
+		_setSettings('localLobbySettings', settings.localLobbySettings);
+		// setLobbySettings({
+		// 	type: 'set',
+		// 	action: settings.localLobbySettings,
+		// });
 	}, [settings.localLobbySettings, hostRef.current.isHost]);
 
 	useEffect(() => {
@@ -1082,18 +1084,12 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 						if (parsedData.hasOwnProperty('maxDistance')) {
 							if (!hostRef.current || hostRef.current.parsedHostId !== socketClientsRef.current[peer]?.clientId) return;
 
-							Object.keys(lobbySettings).forEach((field: string) => {
+							(Object.keys(lobbySettings) as (keyof ILobbySettings)[]).forEach((field: keyof ILobbySettings) => {
 								if (field in parsedData) {
-									setLobbySettings({
-										type: 'setOne',
-										action: [field, parsedData[field]],
-									});
+									setLobbySettings(field, parsedData[field]);
 								} else {
 									if (field in defaultlocalLobbySettings) {
-										setLobbySettings({
-											type: 'setOne',
-											action: [field, defaultlocalLobbySettings[field as keyof ILobbySettings]],
-										});
+										setLobbySettings(field, defaultlocalLobbySettings[field]);
 									}
 								}
 							});

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import io, { Socket } from 'socket.io-client';
 import Avatar from './Avatar';
-import { GameStateContext, /*LobbySettingsContext,*/ PlayerColorContext, SettingsContext } from './contexts';
+import { GameStateContext, PlayerColorContext, SettingsContext } from './contexts';
 import {
 	AmongUsState,
 	GameState,
@@ -30,7 +30,7 @@ import radioOnSound from '../../static/sounds/radio_on.wav'; // @ts-ignore
 // import radioBeep2 from '../../static/sounds/radio_beep2.wav';
 
 import { CameraLocation, AmongUsMaps, MapType } from '../common/AmongusMap';
-import Store from 'electron-store';
+// import Store from 'electron-store';
 import { ObsVoiceState } from '../common/ObsOverlay';
 // import { poseCollide } from '../common/ColliderMap';
 import Footer from './Footer';
@@ -42,7 +42,7 @@ import Mic from '@material-ui/icons/Mic';
 import MicOff from '@material-ui/icons/MicOff';
 import adapter from 'webrtc-adapter';
 import { VADOptions } from './vad';
-import { pushToTalkOptions } from './settings/SettingsStore';
+import { pushToTalkOptions, setSetting } from './settings/SettingsStore';
 import { poseCollide } from '../common/ColliderMap';
 
 console.log(adapter.browserDetails.browser);
@@ -219,7 +219,7 @@ radioOnAudio.volume = 0.02;
 
 
 // TODO: Check: does this really need it's own reference?
-const store = new Store<ISettings>();
+// const store = new Store<ISettings>();
 const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceProps) {
 	const [error, setError] = useState('');
 	const [settings, _setSettings, setLobbySettings] = useContext(SettingsContext);
@@ -1479,7 +1479,8 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 										size={50}
 										socketConfig={socketConfig}
 										onConfigChange={() => {
-											store.set(`playerConfigMap.${player.nameHash}`, playerConfigs[player.nameHash]);
+											setSetting(`playerConfigMap.${player.nameHash}`, playerConfigs[player.nameHash]);
+											// store.set(`playerConfigMap.${player.nameHash}`, playerConfigs[player.nameHash]);
 										}}
 										mod={gameState.mod}
 									/>

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -862,300 +862,597 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 
 		// Get microphone settings
 		if (settingsRef.current.microphone.toLowerCase() !== 'default') audio.deviceId = settingsRef.current.microphone;
-		navigator.getUserMedia(
-			{ video: false, audio },
-			async (inStream) => {
-				let stream = inStream;
-				const ac = new AudioContext();
-				let microphoneGain: GainNode | undefined;
-				const source = ac.createMediaStreamSource(inStream);
-				if (settings.microphoneGainEnabled || settings.micSensitivityEnabled) {
-					console.log('Microphone volume or sensitivityEnabled..');
-					stream = (() => {
-						microphoneGain = ac.createGain();
-						const destination = ac.createMediaStreamDestination();
-						source.connect(microphoneGain);
-						microphoneGain.gain.value = settings.microphoneGainEnabled ? settings.microphoneGain / 100 : 1;
-						microphoneGain.connect(destination);
-						connectionStuff.current.microphoneGain = microphoneGain;
-						return destination.stream;
-					})();
-				}
-
-				if (settingsRef.current.vadEnabled) {
-					audioListener = VAD(ac, source, undefined, {
-						onVoiceStart: () => {
-							if (microphoneGain && settingsRef.current.micSensitivityEnabled) {
-								microphoneGain.gain.value = settingsRef.current.microphoneGainEnabled
-									? settingsRef.current.microphoneGain / 100
-									: 1;
-							}
-							setTalking(true);
-						},
-						onVoiceStop: () => {
-							if (microphoneGain && settingsRef.current.micSensitivityEnabled) {
-								microphoneGain.gain.value = 0;
-							}
-							setTalking(false);
-						},
-						noiseCaptureDuration: 0,
-						stereo: false,
-					});
-
-					audioListener.options.minNoiseLevel = settingsRef.current.micSensitivityEnabled
-						? settingsRef.current.micSensitivity
-						: 0.15;
-					audioListener.options.maxNoiseLevel = 1;
-
-					audioListener.init();
-					connectionStuff.current.audioListener = audioListener;
+		navigator.mediaDevices.getUserMedia({ video: false, audio })
+		.then(async (inStream) => {
+			let stream = inStream;
+			const ac = new AudioContext();
+			let microphoneGain: GainNode | undefined;
+			const source = ac.createMediaStreamSource(inStream);
+			if (settings.microphoneGainEnabled || settings.micSensitivityEnabled) {
+				console.log('Microphone volume or sensitivityEnabled..');
+				stream = (() => {
+					microphoneGain = ac.createGain();
+					const destination = ac.createMediaStreamDestination();
+					source.connect(microphoneGain);
+					microphoneGain.gain.value = settings.microphoneGainEnabled ? settings.microphoneGain / 100 : 1;
+					microphoneGain.connect(destination);
 					connectionStuff.current.microphoneGain = microphoneGain;
-				}
-				connectionStuff.current.stream = stream;
-				connectionStuff.current.instream = inStream;
-
-				inStream.getAudioTracks()[0].enabled = settings.pushToTalkMode !== pushToTalkOptions.PUSH_TO_TALK;
-
-				connectionStuff.current.toggleDeafen = () => {
-					connectionStuff.current.deafened = !connectionStuff.current.deafened;
-					inStream.getAudioTracks()[0].enabled =
-						!connectionStuff.current.deafened &&
-						!connectionStuff.current.muted &&
-						connectionStuff.current.pushToTalkMode !== pushToTalkOptions.PUSH_TO_TALK;
-					setDeafened(connectionStuff.current.deafened);
-				};
-
-				connectionStuff.current.toggleMute = () => {
-					connectionStuff.current.muted = !connectionStuff.current.muted;
-					if (connectionStuff.current.deafened) {
-						connectionStuff.current.deafened = false;
-						connectionStuff.current.muted = false;
-					}
-					inStream.getAudioTracks()[0].enabled =
-						!connectionStuff.current.muted &&
-						!connectionStuff.current.deafened &&
-						connectionStuff.current.pushToTalkMode !== pushToTalkOptions.PUSH_TO_TALK;
-					setMuted(connectionStuff.current.muted);
-					setDeafened(connectionStuff.current.deafened);
-				};
-
-				ipcRenderer.on(IpcRendererMessages.TOGGLE_DEAFEN, connectionStuff.current.toggleDeafen);
-
-				ipcRenderer.on(IpcRendererMessages.IMPOSTOR_RADIO, (_: unknown, pressing: boolean) => {
-					connectionStuff.current.impostorRadio = pressing;
-				});
-
-				ipcRenderer.on(IpcRendererMessages.TOGGLE_MUTE, connectionStuff.current.toggleMute);
-				ipcRenderer.on(IpcRendererMessages.PUSH_TO_TALK, (_: unknown, pressing: boolean) => {
-					if (connectionStuff.current.pushToTalkMode === pushToTalkOptions.VOICE) return;
-					if (!connectionStuff.current.deafened) {
-						inStream.getAudioTracks()[0].enabled =
-							connectionStuff.current.pushToTalkMode === pushToTalkOptions.PUSH_TO_TALK ? pressing : !pressing;
-					}
-				});
-
-				audioElements.current = {};
-
-				const connect = (lobbyCode: string, playerId: number, clientId: number, isHost: boolean) => {
-					console.log('connect called..', lobbyCode);
-					setOtherVAD({});
-					setOtherTalking({});
-					if (lobbyCode === 'MENU') {
-						Object.keys(peerConnections).forEach((k) => {
-							disconnectPeer(k);
-						});
-						setSocketClients({});
-						currentLobby = lobbyCode;
-					} else if (currentLobby !== lobbyCode) {
-						console.log('Currentlobby', currentLobby, lobbyCode);
-						socket.emit('leave');
-						socket.emit('id', playerId, clientId);
-						socket.emit('join', lobbyCode, playerId, clientId, isHost);
-						currentLobby = lobbyCode;
-					}
-				};
-
-				setConnect({ connect });
-
-				function createPeerConnection(peer: string, initiator: boolean, client: Client) {
-					console.log('CreatePeerConnection: ', peer, initiator);
-					disconnectClient(client);
-					const connection = new Peer({
-						stream,
-						initiator, // @ts-ignore-line
-						iceRestartEnabled: true,
-						config: settingsRef.current.natFix ? DEFAULT_ICE_CONFIG_TURN : iceConfig,
-					});
-
-					setPeerConnections((connections) => {
-						connections[peer] = connection;
-						return connections;
-					});
-
-					connection.on('connect', () => {
-						setTimeout(() => {
-							if (hostRef.current.isHost && connection.writable) {
-								try {
-									console.log('sending settings..');
-									connection.send(JSON.stringify(lobbySettingsRef.current));
-								} catch (e) {
-									console.warn('failed to update lobby settings: ', e);
-								}
-							}
-						}, 1000);
-					});
-
-					connection.on('stream', async (stream: MediaStream) => {
-						console.log('ONSTREAM');
-
-						setAudioConnected((old) => ({ ...old, [peer]: true }));
-						const dummyAudio = new Audio();
-						dummyAudio.srcObject = stream;
-						const context = new AudioContext();
-						const source = context.createMediaStreamSource(stream);
-						const dest = context.createMediaStreamDestination();
-
-						const gain = context.createGain();
-						const pan = context.createPanner();
-						gain.gain.value = 0;
-						pan.refDistance = 0.1;
-						pan.panningModel = 'equalpower';
-						pan.distanceModel = 'linear';
-						pan.maxDistance = maxDistanceRef.current;
-						pan.rolloffFactor = 1;
-
-						const muffle = context.createBiquadFilter();
-						muffle.type = 'lowpass';
-
-						source.connect(pan);
-						pan.connect(gain);
-
-						const reverb = context.createConvolver();
-						reverb.buffer = convolverBuffer.current;
-						const destination: AudioNode = dest;
-						// if (settingsRef.current.vadEnabled) {
-						// 	VAD(context, gain, undefined, {
-						// 		onVoiceStart: () => setTalking(true),
-						// 		onVoiceStop: () => setTalking(false),
-						// 		stereo: false,
-						// 	});
-						// }
-						gain.connect(destination);
-						const audio = document.createElement('audio') as ExtendedAudioElement;
-						document.body.appendChild(audio);
-						audio.setAttribute('autoplay', '');
-						audio.srcObject = dest.stream;
-						if (settingsRef.current.speaker.toLowerCase() !== 'default') {
-							audio.setSinkId(settingsRef.current.speaker);
-						}
-
-
-						audioElements.current[peer] = {
-							dummyAudioElement: dummyAudio,
-							audioElement: audio,
-							gain,
-							pan,
-							reverb,
-							muffle,
-							muffleConnected: false,
-							reverbConnected: false,
-							destination,
-						};
-					});
-
-					connection.on('signal', (data) => {
-						socket.emit('signal', {
-							data,
-							to: peer,
-						});
-					});
-
-					connection.on('data', (data) => {
-						const parsedData = JSON.parse(data);
-						if (parsedData.hasOwnProperty('impostorRadio')) {
-							const clientId = socketClientsRef.current[peer]?.clientId;
-							if (impostorRadioClientId.current === -1 && parsedData['impostorRadio']) {
-								impostorRadioClientId.current = clientId;
-							} else if (impostorRadioClientId.current === clientId && !parsedData['impostorRadio']) {
-								impostorRadioClientId.current = -1;
-							}
-							console.log('Recieved impostor radio request', parsedData);
-						}
-						if (parsedData.hasOwnProperty('maxDistance')) {
-							if (!hostRef.current || hostRef.current.parsedHostId !== socketClientsRef.current[peer]?.clientId) return;
-
-							(Object.keys(lobbySettings) as (keyof ILobbySettings)[]).forEach((field: keyof ILobbySettings) => {
-								if (field in parsedData) {
-									setLobbySettings(field, parsedData[field]);
-								} else {
-									if (field in defaultlocalLobbySettings) {
-										setLobbySettings(field, defaultlocalLobbySettings[field]);
-									}
-								}
-							});
-						}
-					});
-					connection.on('close', () => {
-						console.log('Disconnected from', peer, 'Initiator:', initiator);
-						disconnectPeer(peer);
-					});
-					connection.on('error', () => {
-						console.log('ONERROR');
-						/*empty*/
-					});
-					return connection;
-				}
-
-				socket.on('join', async (peer: string, client: Client) => {
-					createPeerConnection(peer, true, client);
-					setSocketClients((old) => ({ ...old, [peer]: client }));
-				});
-
-				socket.on('signal', ({ data, from, client }: { data: Peer.SignalData; from: string, client: Client }) => {
-					//console.log('onsignal', JSON.stringify(data));
-					if (data.hasOwnProperty('mobilePlayerInfo')) {
-						// eslint-disable-line
-						const mobiledata = data as mobileHostInfo;
-						if (
-							mobiledata.mobilePlayerInfo.code === hostRef.current.code &&
-							hostRef.current.gamestate !== GameState.MENU
-						) {
-							hostRef.current.mobileRunning = true;
-							console.log('setting mobileRunning to true..');
-						}
-						return;
-					}
-					//console.log('ONSIGNAL', data, client);
-					let connection: Peer.Instance;
-					if (!socketClientsRef.current[from]) {
-						console.warn('SIGNAL FROM UNKOWN SOCKET..');
-						return;
-					}
-					if (data.hasOwnProperty('type')) {
-						// if (data.type === 'offer' && peerConnections[from]) {
-						// 	console.log("Got offer with already a connection")
-						// }
-						if (peerConnections[from] && data.type !== 'offer') {
-							//	console.log('Send to existing peer 1');
-							connection = peerConnections[from];
-						} else {
-							//	console.log('Send to new peer 1');
-
-							connection = createPeerConnection(from, false, client);
-						}
-						connection.signal(data);
-					}
-				});
-			},
-			(error) => {
-				console.error(error);
-				setError("Couldn't connect to your microphone:\n" + error);
-				// ipcRenderer.send(IpcMessages.SHOW_ERROR_DIALOG, {
-				// 	title: 'Error',
-				// 	content: 'Couldn\'t connect to your microphone:\n' + error
-				// });
+					return destination.stream;
+				})();
 			}
-		);
+
+			if (settingsRef.current.vadEnabled) {
+				audioListener = VAD(ac, source, undefined, {
+					onVoiceStart: () => {
+						if (microphoneGain && settingsRef.current.micSensitivityEnabled) {
+							microphoneGain.gain.value = settingsRef.current.microphoneGainEnabled
+								? settingsRef.current.microphoneGain / 100
+								: 1;
+						}
+						setTalking(true);
+					},
+					onVoiceStop: () => {
+						if (microphoneGain && settingsRef.current.micSensitivityEnabled) {
+							microphoneGain.gain.value = 0;
+						}
+						setTalking(false);
+					},
+					noiseCaptureDuration: 0,
+					stereo: false,
+				});
+
+				audioListener.options.minNoiseLevel = settingsRef.current.micSensitivityEnabled
+					? settingsRef.current.micSensitivity
+					: 0.15;
+				audioListener.options.maxNoiseLevel = 1;
+
+				audioListener.init();
+				connectionStuff.current.audioListener = audioListener;
+				connectionStuff.current.microphoneGain = microphoneGain;
+			}
+			connectionStuff.current.stream = stream;
+			connectionStuff.current.instream = inStream;
+
+			inStream.getAudioTracks()[0].enabled = settings.pushToTalkMode !== pushToTalkOptions.PUSH_TO_TALK;
+
+			connectionStuff.current.toggleDeafen = () => {
+				connectionStuff.current.deafened = !connectionStuff.current.deafened;
+				inStream.getAudioTracks()[0].enabled =
+					!connectionStuff.current.deafened &&
+					!connectionStuff.current.muted &&
+					connectionStuff.current.pushToTalkMode !== pushToTalkOptions.PUSH_TO_TALK;
+				setDeafened(connectionStuff.current.deafened);
+			};
+
+			connectionStuff.current.toggleMute = () => {
+				connectionStuff.current.muted = !connectionStuff.current.muted;
+				if (connectionStuff.current.deafened) {
+					connectionStuff.current.deafened = false;
+					connectionStuff.current.muted = false;
+				}
+				inStream.getAudioTracks()[0].enabled =
+					!connectionStuff.current.muted &&
+					!connectionStuff.current.deafened &&
+					connectionStuff.current.pushToTalkMode !== pushToTalkOptions.PUSH_TO_TALK;
+				setMuted(connectionStuff.current.muted);
+				setDeafened(connectionStuff.current.deafened);
+			};
+
+			ipcRenderer.on(IpcRendererMessages.TOGGLE_DEAFEN, connectionStuff.current.toggleDeafen);
+
+			ipcRenderer.on(IpcRendererMessages.IMPOSTOR_RADIO, (_: unknown, pressing: boolean) => {
+				connectionStuff.current.impostorRadio = pressing;
+			});
+
+			ipcRenderer.on(IpcRendererMessages.TOGGLE_MUTE, connectionStuff.current.toggleMute);
+			ipcRenderer.on(IpcRendererMessages.PUSH_TO_TALK, (_: unknown, pressing: boolean) => {
+				if (connectionStuff.current.pushToTalkMode === pushToTalkOptions.VOICE) return;
+				if (!connectionStuff.current.deafened) {
+					inStream.getAudioTracks()[0].enabled =
+						connectionStuff.current.pushToTalkMode === pushToTalkOptions.PUSH_TO_TALK ? pressing : !pressing;
+				}
+			});
+
+			audioElements.current = {};
+
+			const connect = (lobbyCode: string, playerId: number, clientId: number, isHost: boolean) => {
+				console.log('connect called..', lobbyCode);
+				setOtherVAD({});
+				setOtherTalking({});
+				if (lobbyCode === 'MENU') {
+					Object.keys(peerConnections).forEach((k) => {
+						disconnectPeer(k);
+					});
+					setSocketClients({});
+					currentLobby = lobbyCode;
+				} else if (currentLobby !== lobbyCode) {
+					console.log('Currentlobby', currentLobby, lobbyCode);
+					socket.emit('leave');
+					socket.emit('id', playerId, clientId);
+					socket.emit('join', lobbyCode, playerId, clientId, isHost);
+					currentLobby = lobbyCode;
+				}
+			};
+
+			setConnect({ connect });
+
+			function createPeerConnection(peer: string, initiator: boolean, client: Client) {
+				console.log('CreatePeerConnection: ', peer, initiator);
+				disconnectClient(client);
+				const connection = new Peer({
+					stream,
+					initiator, // @ts-ignore-line
+					iceRestartEnabled: true,
+					config: settingsRef.current.natFix ? DEFAULT_ICE_CONFIG_TURN : iceConfig,
+				});
+
+				setPeerConnections((connections) => {
+					connections[peer] = connection;
+					return connections;
+				});
+
+				connection.on('connect', () => {
+					setTimeout(() => {
+						if (hostRef.current.isHost && connection.writable) {
+							try {
+								console.log('sending settings..');
+								connection.send(JSON.stringify(lobbySettingsRef.current));
+							} catch (e) {
+								console.warn('failed to update lobby settings: ', e);
+							}
+						}
+					}, 1000);
+				});
+
+				connection.on('stream', async (stream: MediaStream) => {
+					console.log('ONSTREAM');
+
+					setAudioConnected((old) => ({ ...old, [peer]: true }));
+					const dummyAudio = new Audio();
+					dummyAudio.srcObject = stream;
+					const context = new AudioContext();
+					const source = context.createMediaStreamSource(stream);
+					const dest = context.createMediaStreamDestination();
+
+					const gain = context.createGain();
+					const pan = context.createPanner();
+					gain.gain.value = 0;
+					pan.refDistance = 0.1;
+					pan.panningModel = 'equalpower';
+					pan.distanceModel = 'linear';
+					pan.maxDistance = maxDistanceRef.current;
+					pan.rolloffFactor = 1;
+
+					const muffle = context.createBiquadFilter();
+					muffle.type = 'lowpass';
+
+					source.connect(pan);
+					pan.connect(gain);
+
+					const reverb = context.createConvolver();
+					reverb.buffer = convolverBuffer.current;
+					const destination: AudioNode = dest;
+					// if (settingsRef.current.vadEnabled) {
+					// 	VAD(context, gain, undefined, {
+					// 		onVoiceStart: () => setTalking(true),
+					// 		onVoiceStop: () => setTalking(false),
+					// 		stereo: false,
+					// 	});
+					// }
+					gain.connect(destination);
+					const audio = document.createElement('audio') as ExtendedAudioElement;
+					document.body.appendChild(audio);
+					audio.setAttribute('autoplay', '');
+					audio.srcObject = dest.stream;
+					if (settingsRef.current.speaker.toLowerCase() !== 'default') {
+						audio.setSinkId(settingsRef.current.speaker);
+					}
+
+
+					audioElements.current[peer] = {
+						dummyAudioElement: dummyAudio,
+						audioElement: audio,
+						gain,
+						pan,
+						reverb,
+						muffle,
+						muffleConnected: false,
+						reverbConnected: false,
+						destination,
+					};
+				});
+
+				connection.on('signal', (data) => {
+					socket.emit('signal', {
+						data,
+						to: peer,
+					});
+				});
+
+				connection.on('data', (data) => {
+					const parsedData = JSON.parse(data);
+					if (parsedData.hasOwnProperty('impostorRadio')) {
+						const clientId = socketClientsRef.current[peer]?.clientId;
+						if (impostorRadioClientId.current === -1 && parsedData['impostorRadio']) {
+							impostorRadioClientId.current = clientId;
+						} else if (impostorRadioClientId.current === clientId && !parsedData['impostorRadio']) {
+							impostorRadioClientId.current = -1;
+						}
+						console.log('Recieved impostor radio request', parsedData);
+					}
+					if (parsedData.hasOwnProperty('maxDistance')) {
+						if (!hostRef.current || hostRef.current.parsedHostId !== socketClientsRef.current[peer]?.clientId) return;
+
+						(Object.keys(lobbySettings) as (keyof ILobbySettings)[]).forEach((field: keyof ILobbySettings) => {
+							if (field in parsedData) {
+								setLobbySettings(field, parsedData[field]);
+							} else {
+								if (field in defaultlocalLobbySettings) {
+									setLobbySettings(field, defaultlocalLobbySettings[field]);
+								}
+							}
+						});
+					}
+				});
+				connection.on('close', () => {
+					console.log('Disconnected from', peer, 'Initiator:', initiator);
+					disconnectPeer(peer);
+				});
+				connection.on('error', () => {
+					console.log('ONERROR');
+					/*empty*/
+				});
+				return connection;
+			}
+
+			socket.on('join', async (peer: string, client: Client) => {
+				createPeerConnection(peer, true, client);
+				setSocketClients((old) => ({ ...old, [peer]: client }));
+			});
+
+			socket.on('signal', ({ data, from, client }: { data: Peer.SignalData; from: string, client: Client }) => {
+				//console.log('onsignal', JSON.stringify(data));
+				if (data.hasOwnProperty('mobilePlayerInfo')) {
+					// eslint-disable-line
+					const mobiledata = data as mobileHostInfo;
+					if (
+						mobiledata.mobilePlayerInfo.code === hostRef.current.code &&
+						hostRef.current.gamestate !== GameState.MENU
+					) {
+						hostRef.current.mobileRunning = true;
+						console.log('setting mobileRunning to true..');
+					}
+					return;
+				}
+				//console.log('ONSIGNAL', data, client);
+				let connection: Peer.Instance;
+				if (!socketClientsRef.current[from]) {
+					console.warn('SIGNAL FROM UNKOWN SOCKET..');
+					return;
+				}
+				if (data.hasOwnProperty('type')) {
+					// if (data.type === 'offer' && peerConnections[from]) {
+					// 	console.log("Got offer with already a connection")
+					// }
+					if (peerConnections[from] && data.type !== 'offer') {
+						//	console.log('Send to existing peer 1');
+						connection = peerConnections[from];
+					} else {
+						//	console.log('Send to new peer 1');
+
+						connection = createPeerConnection(from, false, client);
+					}
+					connection.signal(data);
+				}
+			});
+		},
+		(error) => {
+			console.error(error);
+			setError("Couldn't connect to your microphone:\n" + error);
+			// ipcRenderer.send(IpcMessages.SHOW_ERROR_DIALOG, {
+			// 	title: 'Error',
+			// 	content: 'Couldn\'t connect to your microphone:\n' + error
+			// });
+		});
+		// navigator.getUserMedia(
+		// 	{ video: false, audio },
+		// 	async (inStream) => {
+		// 		let stream = inStream;
+		// 		const ac = new AudioContext();
+		// 		let microphoneGain: GainNode | undefined;
+		// 		const source = ac.createMediaStreamSource(inStream);
+		// 		if (settings.microphoneGainEnabled || settings.micSensitivityEnabled) {
+		// 			console.log('Microphone volume or sensitivityEnabled..');
+		// 			stream = (() => {
+		// 				microphoneGain = ac.createGain();
+		// 				const destination = ac.createMediaStreamDestination();
+		// 				source.connect(microphoneGain);
+		// 				microphoneGain.gain.value = settings.microphoneGainEnabled ? settings.microphoneGain / 100 : 1;
+		// 				microphoneGain.connect(destination);
+		// 				connectionStuff.current.microphoneGain = microphoneGain;
+		// 				return destination.stream;
+		// 			})();
+		// 		}
+
+		// 		if (settingsRef.current.vadEnabled) {
+		// 			audioListener = VAD(ac, source, undefined, {
+		// 				onVoiceStart: () => {
+		// 					if (microphoneGain && settingsRef.current.micSensitivityEnabled) {
+		// 						microphoneGain.gain.value = settingsRef.current.microphoneGainEnabled
+		// 							? settingsRef.current.microphoneGain / 100
+		// 							: 1;
+		// 					}
+		// 					setTalking(true);
+		// 				},
+		// 				onVoiceStop: () => {
+		// 					if (microphoneGain && settingsRef.current.micSensitivityEnabled) {
+		// 						microphoneGain.gain.value = 0;
+		// 					}
+		// 					setTalking(false);
+		// 				},
+		// 				noiseCaptureDuration: 0,
+		// 				stereo: false,
+		// 			});
+
+		// 			audioListener.options.minNoiseLevel = settingsRef.current.micSensitivityEnabled
+		// 				? settingsRef.current.micSensitivity
+		// 				: 0.15;
+		// 			audioListener.options.maxNoiseLevel = 1;
+
+		// 			audioListener.init();
+		// 			connectionStuff.current.audioListener = audioListener;
+		// 			connectionStuff.current.microphoneGain = microphoneGain;
+		// 		}
+		// 		connectionStuff.current.stream = stream;
+		// 		connectionStuff.current.instream = inStream;
+
+		// 		inStream.getAudioTracks()[0].enabled = settings.pushToTalkMode !== pushToTalkOptions.PUSH_TO_TALK;
+
+		// 		connectionStuff.current.toggleDeafen = () => {
+		// 			connectionStuff.current.deafened = !connectionStuff.current.deafened;
+		// 			inStream.getAudioTracks()[0].enabled =
+		// 				!connectionStuff.current.deafened &&
+		// 				!connectionStuff.current.muted &&
+		// 				connectionStuff.current.pushToTalkMode !== pushToTalkOptions.PUSH_TO_TALK;
+		// 			setDeafened(connectionStuff.current.deafened);
+		// 		};
+
+		// 		connectionStuff.current.toggleMute = () => {
+		// 			connectionStuff.current.muted = !connectionStuff.current.muted;
+		// 			if (connectionStuff.current.deafened) {
+		// 				connectionStuff.current.deafened = false;
+		// 				connectionStuff.current.muted = false;
+		// 			}
+		// 			inStream.getAudioTracks()[0].enabled =
+		// 				!connectionStuff.current.muted &&
+		// 				!connectionStuff.current.deafened &&
+		// 				connectionStuff.current.pushToTalkMode !== pushToTalkOptions.PUSH_TO_TALK;
+		// 			setMuted(connectionStuff.current.muted);
+		// 			setDeafened(connectionStuff.current.deafened);
+		// 		};
+
+		// 		ipcRenderer.on(IpcRendererMessages.TOGGLE_DEAFEN, connectionStuff.current.toggleDeafen);
+
+		// 		ipcRenderer.on(IpcRendererMessages.IMPOSTOR_RADIO, (_: unknown, pressing: boolean) => {
+		// 			connectionStuff.current.impostorRadio = pressing;
+		// 		});
+
+		// 		ipcRenderer.on(IpcRendererMessages.TOGGLE_MUTE, connectionStuff.current.toggleMute);
+		// 		ipcRenderer.on(IpcRendererMessages.PUSH_TO_TALK, (_: unknown, pressing: boolean) => {
+		// 			if (connectionStuff.current.pushToTalkMode === pushToTalkOptions.VOICE) return;
+		// 			if (!connectionStuff.current.deafened) {
+		// 				inStream.getAudioTracks()[0].enabled =
+		// 					connectionStuff.current.pushToTalkMode === pushToTalkOptions.PUSH_TO_TALK ? pressing : !pressing;
+		// 			}
+		// 		});
+
+		// 		audioElements.current = {};
+
+		// 		const connect = (lobbyCode: string, playerId: number, clientId: number, isHost: boolean) => {
+		// 			console.log('connect called..', lobbyCode);
+		// 			setOtherVAD({});
+		// 			setOtherTalking({});
+		// 			if (lobbyCode === 'MENU') {
+		// 				Object.keys(peerConnections).forEach((k) => {
+		// 					disconnectPeer(k);
+		// 				});
+		// 				setSocketClients({});
+		// 				currentLobby = lobbyCode;
+		// 			} else if (currentLobby !== lobbyCode) {
+		// 				console.log('Currentlobby', currentLobby, lobbyCode);
+		// 				socket.emit('leave');
+		// 				socket.emit('id', playerId, clientId);
+		// 				socket.emit('join', lobbyCode, playerId, clientId, isHost);
+		// 				currentLobby = lobbyCode;
+		// 			}
+		// 		};
+
+		// 		setConnect({ connect });
+
+		// 		function createPeerConnection(peer: string, initiator: boolean) {
+		// 			console.log('CreatePeerConnection: ', peer, initiator);
+
+		// 			const connection = new Peer({
+		// 				stream,
+		// 				initiator, // @ts-ignore-line
+		// 				iceRestartEnabled: true,
+		// 				config: settingsRef.current.natFix ? DEFAULT_ICE_CONFIG_TURN : iceConfig,
+		// 			});
+
+		// 			setPeerConnections((connections) => {
+		// 				connections[peer] = connection;
+		// 				return connections;
+		// 			});
+
+		// 			connection.on('connect', () => {
+		// 				setTimeout(() => {
+		// 					if (hostRef.current.isHost && connection.writable) {
+		// 						try {
+		// 							console.log('sending settings..');
+		// 							connection.send(JSON.stringify(lobbySettingsRef.current));
+		// 						} catch (e) {
+		// 							console.warn('failed to update lobby settings: ', e);
+		// 						}
+		// 					}
+		// 				}, 1000);
+		// 			});
+
+		// 			connection.on('stream', async (stream: MediaStream) => {
+		// 				console.log('ONSTREAM');
+
+		// 				setAudioConnected((old) => ({ ...old, [peer]: true }));
+		// 				const dummyAudio = new Audio();
+		// 				dummyAudio.srcObject = stream;
+		// 				const context = new AudioContext();
+		// 				const source = context.createMediaStreamSource(stream);
+		// 				const dest = context.createMediaStreamDestination();
+
+		// 				const gain = context.createGain();
+		// 				const pan = context.createPanner();
+		// 				gain.gain.value = 0;
+		// 				pan.refDistance = 0.1;
+		// 				pan.panningModel = 'equalpower';
+		// 				pan.distanceModel = 'linear';
+		// 				pan.maxDistance = maxDistanceRef.current;
+		// 				pan.rolloffFactor = 1;
+
+		// 				const muffle = context.createBiquadFilter();
+		// 				muffle.type = 'lowpass';
+
+		// 				source.connect(pan);
+		// 				pan.connect(gain);
+
+		// 				const reverb = context.createConvolver();
+		// 				reverb.buffer = convolverBuffer.current;
+		// 				const destination: AudioNode = dest;
+		// 				// if (settingsRef.current.vadEnabled) {
+		// 				// 	VAD(context, gain, undefined, {
+		// 				// 		onVoiceStart: () => setTalking(true),
+		// 				// 		onVoiceStop: () => setTalking(false),
+		// 				// 		stereo: false,
+		// 				// 	});
+		// 				// }
+		// 				gain.connect(destination);
+		// 				const audio = document.createElement('audio') as ExtendedAudioElement;
+		// 				document.body.appendChild(audio);
+		// 				audio.setAttribute('autoplay', '');
+		// 				audio.srcObject = dest.stream;
+		// 				if (settingsRef.current.speaker.toLowerCase() !== 'default') {
+		// 					audio.setSinkId(settingsRef.current.speaker);
+		// 				}
+
+		// 				if (audioElements.current[peer]) {
+		// 					disconnectAudioElement(peer);
+		// 				}
+		// 				audioElements.current[peer] = {
+		// 					dummyAudioElement: dummyAudio,
+		// 					audioElement: audio,
+		// 					gain,
+		// 					pan,
+		// 					reverb,
+		// 					muffle,
+		// 					muffleConnected: false,
+		// 					reverbConnected: false,
+		// 					destination,
+		// 				};
+		// 			});
+
+		// 			connection.on('signal', (data) => {
+		// 				socket.emit('signal', {
+		// 					data,
+		// 					to: peer,
+		// 				});
+		// 			});
+
+		// 			connection.on('data', (data) => {
+		// 				const parsedData = JSON.parse(data);
+		// 				if (parsedData.hasOwnProperty('impostorRadio')) {
+		// 					const clientId = socketClientsRef.current[peer]?.clientId;
+		// 					if (impostorRadioClientId.current === -1 && parsedData['impostorRadio']) {
+		// 						impostorRadioClientId.current = clientId;
+		// 					} else if (impostorRadioClientId.current === clientId && !parsedData['impostorRadio']) {
+		// 						impostorRadioClientId.current = -1;
+		// 					}
+		// 					console.log('Recieved impostor radio request', parsedData);
+		// 				}
+		// 				if (parsedData.hasOwnProperty('maxDistance')) {
+		// 					if (!hostRef.current || hostRef.current.parsedHostId !== socketClientsRef.current[peer]?.clientId) return;
+
+		// 					(Object.keys(lobbySettings) as (keyof ILobbySettings)[]).forEach((field: keyof ILobbySettings) => {
+		// 						if (field in parsedData) {
+		// 							setLobbySettings(field, parsedData[field]);
+		// 						} else {
+		// 							if (field in defaultlocalLobbySettings) {
+		// 								setLobbySettings(field, defaultlocalLobbySettings[field]);
+		// 							}
+		// 						}
+		// 					});
+		// 				}
+		// 			});
+		// 			connection.on('close', () => {
+		// 				console.log('Disconnected from', peer, 'Initiator:', initiator);
+		// 				disconnectPeer(peer);
+		// 			});
+		// 			connection.on('error', () => {
+		// 				console.log('ONERROR');
+		// 				/*empty*/
+		// 			});
+		// 			return connection;
+		// 		}
+
+		// 		socket.on('join', async (peer: string, client: Client) => {
+		// 			const oldSocketId = playerSocketIdsRef.current[client.clientId];
+		// 			if (oldSocketId && audioElements.current[oldSocketId]) {
+		// 				disconnectAudioElement(oldSocketId);
+		// 			}
+		// 			createPeerConnection(peer, true);
+		// 			setSocketClients((old) => ({ ...old, [peer]: client }));
+		// 		});
+
+		// 		socket.on('signal', ({ data, from }: { data: Peer.SignalData; from: string }) => {
+		// 			//console.log('onsignal', JSON.stringify(data));
+		// 			if (data.hasOwnProperty('mobilePlayerInfo')) {
+		// 				// eslint-disable-line
+		// 				const mobiledata = data as mobileHostInfo;
+		// 				if (
+		// 					mobiledata.mobilePlayerInfo.code === hostRef.current.code &&
+		// 					hostRef.current.gamestate !== GameState.MENU
+		// 				) {
+		// 					hostRef.current.mobileRunning = true;
+		// 					console.log('setting mobileRunning to true..');
+		// 				}
+		// 				return;
+		// 			}
+		// 			console.log('ONSIGNAL', data);
+		// 			let connection: Peer.Instance;
+		// 			if (!socketClientsRef.current[from]) {
+		// 				console.warn('SIGNAL FROM UNKOWN SOCKET..');
+		// 				return;
+		// 			}
+		// 			if (data.hasOwnProperty('type')) {
+		// 				// if (data.type === 'offer' && peerConnections[from]) {
+		// 				// 	console.log("Got offer with already a connection")
+		// 				// }
+		// 				if (peerConnections[from] && data.type !== 'offer') {
+		// 					console.log('Send to existing peer 1');
+		// 					connection = peerConnections[from];
+		// 				} else {
+		// 					console.log('Send to new peer 1');
+		// 					connection = createPeerConnection(from, false);
+		// 				}
+		// 				connection.signal(data);
+		// 			}
+		// 		});
+		// 	},
+		// 	(error) => {
+		// 		console.error(error);
+		// 		setError("Couldn't connect to your microphone:\n" + error);
+		// 		// ipcRenderer.send(IpcMessages.SHOW_ERROR_DIALOG, {
+		// 		// 	title: 'Error',
+		// 		// 	content: 'Couldn\'t connect to your microphone:\n' + error
+		// 		// });
+		// 	}
+		// );
 
 		return () => {
 			hostRef.current.mobileRunning = false;

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import io, { Socket } from 'socket.io-client';
 import Avatar from './Avatar';
-import { GameStateContext, PlayerColorContext, SettingsContext } from './contexts';
+import { GameStateContext, HostSettingsContext, PlayerColorContext, SettingsContext } from './contexts';
 import {
 	AmongUsState,
 	GameState,
@@ -222,11 +222,10 @@ radioOnAudio.volume = 0.02;
 // const store = new Store<ISettings>();
 const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceProps) {
 	const [error, setError] = useState('');
-	const [settings, _setSettings, setLobbySettings] = useContext(SettingsContext);
+	const [settings, _setSettings] = useContext(SettingsContext);
 
 	const settingsRef = useRef<ISettings>(settings);
-	// const [lobbySettings, setLobbySettings] = useContext(LobbySettingsContext);
-	const lobbySettings = settings.localLobbySettings;
+	const [lobbySettings, setHostLobbySettings] = useContext(HostSettingsContext);
 	const lobbySettingsRef = useRef(lobbySettings);
 	const maxDistanceRef = useRef(2);
 	const gameState = useContext(GameStateContext);
@@ -553,7 +552,8 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 			}
 		});
 
-		_setSettings('localLobbySettings', settings.localLobbySettings);
+		setHostLobbySettings(settings.localLobbySettings);
+		// _setSettings('localLobbySettings', settings.localLobbySettings);
 		// setLobbySettings({
 		// 	type: 'set',
 		// 	action: settings.localLobbySettings,
@@ -1082,16 +1082,18 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 					}
 					if (parsedData.hasOwnProperty('maxDistance')) {
 						if (!hostRef.current || hostRef.current.parsedHostId !== socketClientsRef.current[peer]?.clientId) return;
-
-						(Object.keys(lobbySettings) as (keyof ILobbySettings)[]).forEach((field: keyof ILobbySettings) => {
-							if (field in parsedData) {
-								setLobbySettings(field, parsedData[field]);
-							} else {
-								if (field in defaultlocalLobbySettings) {
-									setLobbySettings(field, defaultlocalLobbySettings[field]);
-								}
-							}
-						});
+						// (Object.keys(newSettings) as (keyof ILobbySettings)[]).forEach((field: keyof ILobbySettings) => {
+						// 	if (field in parsedData) {
+						// 		newSettings[field] = parsedData[field]
+						// 		setHostLobbySettings(field, parsedData[field]);
+						// 	} else {
+						// 		if (field in defaultlocalLobbySettings) {
+						// 			setHostLobbySettings(field, defaultlocalLobbySettings[field]);
+						// 		}
+						// 	}
+						// });
+						var newSettings = {...defaultlocalLobbySettings, ...parsedData};
+						setHostLobbySettings(newSettings);
 					}
 				});
 				connection.on('close', () => {

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -30,7 +30,6 @@ import radioOnSound from '../../static/sounds/radio_on.wav'; // @ts-ignore
 // import radioBeep2 from '../../static/sounds/radio_beep2.wav';
 
 import { CameraLocation, AmongUsMaps, MapType } from '../common/AmongusMap';
-// import Store from 'electron-store';
 import { ObsVoiceState } from '../common/ObsOverlay';
 // import { poseCollide } from '../common/ColliderMap';
 import Footer from './Footer';
@@ -217,9 +216,6 @@ radioOnAudio.volume = 0.02;
 // radiobeepAudio2.src = radioBeep2;
 // radiobeepAudio2.volume = 0.2;
 
-
-// TODO: Check: does this really need it's own reference?
-// const store = new Store<ISettings>();
 const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceProps) {
 	const [error, setError] = useState('');
 	const [settings, setSetting] = useContext(SettingsContext);
@@ -553,11 +549,6 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 		});
 
 		setHostLobbySettings(settings.localLobbySettings);
-		// _setSettings('localLobbySettings', settings.localLobbySettings);
-		// setLobbySettings({
-		// 	type: 'set',
-		// 	action: settings.localLobbySettings,
-		// });
 	}, [settings.localLobbySettings, hostRef.current.isHost]);
 
 	useEffect(() => {
@@ -1082,17 +1073,7 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 					}
 					if (parsedData.hasOwnProperty('maxDistance')) {
 						if (!hostRef.current || hostRef.current.parsedHostId !== socketClientsRef.current[peer]?.clientId) return;
-						// (Object.keys(newSettings) as (keyof ILobbySettings)[]).forEach((field: keyof ILobbySettings) => {
-						// 	if (field in parsedData) {
-						// 		newSettings[field] = parsedData[field]
-						// 		setHostLobbySettings(field, parsedData[field]);
-						// 	} else {
-						// 		if (field in defaultlocalLobbySettings) {
-						// 			setHostLobbySettings(field, defaultlocalLobbySettings[field]);
-						// 		}
-						// 	}
-						// });
-						var newSettings = {...defaultlocalLobbySettings, ...parsedData};
+						const newSettings = {...defaultlocalLobbySettings, ...parsedData};
 						setHostLobbySettings(newSettings);
 					}
 				});
@@ -1156,305 +1137,6 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 			// 	content: 'Couldn\'t connect to your microphone:\n' + error
 			// });
 		});
-		// navigator.getUserMedia(
-		// 	{ video: false, audio },
-		// 	async (inStream) => {
-		// 		let stream = inStream;
-		// 		const ac = new AudioContext();
-		// 		let microphoneGain: GainNode | undefined;
-		// 		const source = ac.createMediaStreamSource(inStream);
-		// 		if (settings.microphoneGainEnabled || settings.micSensitivityEnabled) {
-		// 			console.log('Microphone volume or sensitivityEnabled..');
-		// 			stream = (() => {
-		// 				microphoneGain = ac.createGain();
-		// 				const destination = ac.createMediaStreamDestination();
-		// 				source.connect(microphoneGain);
-		// 				microphoneGain.gain.value = settings.microphoneGainEnabled ? settings.microphoneGain / 100 : 1;
-		// 				microphoneGain.connect(destination);
-		// 				connectionStuff.current.microphoneGain = microphoneGain;
-		// 				return destination.stream;
-		// 			})();
-		// 		}
-
-		// 		if (settingsRef.current.vadEnabled) {
-		// 			audioListener = VAD(ac, source, undefined, {
-		// 				onVoiceStart: () => {
-		// 					if (microphoneGain && settingsRef.current.micSensitivityEnabled) {
-		// 						microphoneGain.gain.value = settingsRef.current.microphoneGainEnabled
-		// 							? settingsRef.current.microphoneGain / 100
-		// 							: 1;
-		// 					}
-		// 					setTalking(true);
-		// 				},
-		// 				onVoiceStop: () => {
-		// 					if (microphoneGain && settingsRef.current.micSensitivityEnabled) {
-		// 						microphoneGain.gain.value = 0;
-		// 					}
-		// 					setTalking(false);
-		// 				},
-		// 				noiseCaptureDuration: 0,
-		// 				stereo: false,
-		// 			});
-
-		// 			audioListener.options.minNoiseLevel = settingsRef.current.micSensitivityEnabled
-		// 				? settingsRef.current.micSensitivity
-		// 				: 0.15;
-		// 			audioListener.options.maxNoiseLevel = 1;
-
-		// 			audioListener.init();
-		// 			connectionStuff.current.audioListener = audioListener;
-		// 			connectionStuff.current.microphoneGain = microphoneGain;
-		// 		}
-		// 		connectionStuff.current.stream = stream;
-		// 		connectionStuff.current.instream = inStream;
-
-		// 		inStream.getAudioTracks()[0].enabled = settings.pushToTalkMode !== pushToTalkOptions.PUSH_TO_TALK;
-
-		// 		connectionStuff.current.toggleDeafen = () => {
-		// 			connectionStuff.current.deafened = !connectionStuff.current.deafened;
-		// 			inStream.getAudioTracks()[0].enabled =
-		// 				!connectionStuff.current.deafened &&
-		// 				!connectionStuff.current.muted &&
-		// 				connectionStuff.current.pushToTalkMode !== pushToTalkOptions.PUSH_TO_TALK;
-		// 			setDeafened(connectionStuff.current.deafened);
-		// 		};
-
-		// 		connectionStuff.current.toggleMute = () => {
-		// 			connectionStuff.current.muted = !connectionStuff.current.muted;
-		// 			if (connectionStuff.current.deafened) {
-		// 				connectionStuff.current.deafened = false;
-		// 				connectionStuff.current.muted = false;
-		// 			}
-		// 			inStream.getAudioTracks()[0].enabled =
-		// 				!connectionStuff.current.muted &&
-		// 				!connectionStuff.current.deafened &&
-		// 				connectionStuff.current.pushToTalkMode !== pushToTalkOptions.PUSH_TO_TALK;
-		// 			setMuted(connectionStuff.current.muted);
-		// 			setDeafened(connectionStuff.current.deafened);
-		// 		};
-
-		// 		ipcRenderer.on(IpcRendererMessages.TOGGLE_DEAFEN, connectionStuff.current.toggleDeafen);
-
-		// 		ipcRenderer.on(IpcRendererMessages.IMPOSTOR_RADIO, (_: unknown, pressing: boolean) => {
-		// 			connectionStuff.current.impostorRadio = pressing;
-		// 		});
-
-		// 		ipcRenderer.on(IpcRendererMessages.TOGGLE_MUTE, connectionStuff.current.toggleMute);
-		// 		ipcRenderer.on(IpcRendererMessages.PUSH_TO_TALK, (_: unknown, pressing: boolean) => {
-		// 			if (connectionStuff.current.pushToTalkMode === pushToTalkOptions.VOICE) return;
-		// 			if (!connectionStuff.current.deafened) {
-		// 				inStream.getAudioTracks()[0].enabled =
-		// 					connectionStuff.current.pushToTalkMode === pushToTalkOptions.PUSH_TO_TALK ? pressing : !pressing;
-		// 			}
-		// 		});
-
-		// 		audioElements.current = {};
-
-		// 		const connect = (lobbyCode: string, playerId: number, clientId: number, isHost: boolean) => {
-		// 			console.log('connect called..', lobbyCode);
-		// 			setOtherVAD({});
-		// 			setOtherTalking({});
-		// 			if (lobbyCode === 'MENU') {
-		// 				Object.keys(peerConnections).forEach((k) => {
-		// 					disconnectPeer(k);
-		// 				});
-		// 				setSocketClients({});
-		// 				currentLobby = lobbyCode;
-		// 			} else if (currentLobby !== lobbyCode) {
-		// 				console.log('Currentlobby', currentLobby, lobbyCode);
-		// 				socket.emit('leave');
-		// 				socket.emit('id', playerId, clientId);
-		// 				socket.emit('join', lobbyCode, playerId, clientId, isHost);
-		// 				currentLobby = lobbyCode;
-		// 			}
-		// 		};
-
-		// 		setConnect({ connect });
-
-		// 		function createPeerConnection(peer: string, initiator: boolean) {
-		// 			console.log('CreatePeerConnection: ', peer, initiator);
-
-		// 			const connection = new Peer({
-		// 				stream,
-		// 				initiator, // @ts-ignore-line
-		// 				iceRestartEnabled: true,
-		// 				config: settingsRef.current.natFix ? DEFAULT_ICE_CONFIG_TURN : iceConfig,
-		// 			});
-
-		// 			setPeerConnections((connections) => {
-		// 				connections[peer] = connection;
-		// 				return connections;
-		// 			});
-
-		// 			connection.on('connect', () => {
-		// 				setTimeout(() => {
-		// 					if (hostRef.current.isHost && connection.writable) {
-		// 						try {
-		// 							console.log('sending settings..');
-		// 							connection.send(JSON.stringify(lobbySettingsRef.current));
-		// 						} catch (e) {
-		// 							console.warn('failed to update lobby settings: ', e);
-		// 						}
-		// 					}
-		// 				}, 1000);
-		// 			});
-
-		// 			connection.on('stream', async (stream: MediaStream) => {
-		// 				console.log('ONSTREAM');
-
-		// 				setAudioConnected((old) => ({ ...old, [peer]: true }));
-		// 				const dummyAudio = new Audio();
-		// 				dummyAudio.srcObject = stream;
-		// 				const context = new AudioContext();
-		// 				const source = context.createMediaStreamSource(stream);
-		// 				const dest = context.createMediaStreamDestination();
-
-		// 				const gain = context.createGain();
-		// 				const pan = context.createPanner();
-		// 				gain.gain.value = 0;
-		// 				pan.refDistance = 0.1;
-		// 				pan.panningModel = 'equalpower';
-		// 				pan.distanceModel = 'linear';
-		// 				pan.maxDistance = maxDistanceRef.current;
-		// 				pan.rolloffFactor = 1;
-
-		// 				const muffle = context.createBiquadFilter();
-		// 				muffle.type = 'lowpass';
-
-		// 				source.connect(pan);
-		// 				pan.connect(gain);
-
-		// 				const reverb = context.createConvolver();
-		// 				reverb.buffer = convolverBuffer.current;
-		// 				const destination: AudioNode = dest;
-		// 				// if (settingsRef.current.vadEnabled) {
-		// 				// 	VAD(context, gain, undefined, {
-		// 				// 		onVoiceStart: () => setTalking(true),
-		// 				// 		onVoiceStop: () => setTalking(false),
-		// 				// 		stereo: false,
-		// 				// 	});
-		// 				// }
-		// 				gain.connect(destination);
-		// 				const audio = document.createElement('audio') as ExtendedAudioElement;
-		// 				document.body.appendChild(audio);
-		// 				audio.setAttribute('autoplay', '');
-		// 				audio.srcObject = dest.stream;
-		// 				if (settingsRef.current.speaker.toLowerCase() !== 'default') {
-		// 					audio.setSinkId(settingsRef.current.speaker);
-		// 				}
-
-		// 				if (audioElements.current[peer]) {
-		// 					disconnectAudioElement(peer);
-		// 				}
-		// 				audioElements.current[peer] = {
-		// 					dummyAudioElement: dummyAudio,
-		// 					audioElement: audio,
-		// 					gain,
-		// 					pan,
-		// 					reverb,
-		// 					muffle,
-		// 					muffleConnected: false,
-		// 					reverbConnected: false,
-		// 					destination,
-		// 				};
-		// 			});
-
-		// 			connection.on('signal', (data) => {
-		// 				socket.emit('signal', {
-		// 					data,
-		// 					to: peer,
-		// 				});
-		// 			});
-
-		// 			connection.on('data', (data) => {
-		// 				const parsedData = JSON.parse(data);
-		// 				if (parsedData.hasOwnProperty('impostorRadio')) {
-		// 					const clientId = socketClientsRef.current[peer]?.clientId;
-		// 					if (impostorRadioClientId.current === -1 && parsedData['impostorRadio']) {
-		// 						impostorRadioClientId.current = clientId;
-		// 					} else if (impostorRadioClientId.current === clientId && !parsedData['impostorRadio']) {
-		// 						impostorRadioClientId.current = -1;
-		// 					}
-		// 					console.log('Recieved impostor radio request', parsedData);
-		// 				}
-		// 				if (parsedData.hasOwnProperty('maxDistance')) {
-		// 					if (!hostRef.current || hostRef.current.parsedHostId !== socketClientsRef.current[peer]?.clientId) return;
-
-		// 					(Object.keys(lobbySettings) as (keyof ILobbySettings)[]).forEach((field: keyof ILobbySettings) => {
-		// 						if (field in parsedData) {
-		// 							setLobbySettings(field, parsedData[field]);
-		// 						} else {
-		// 							if (field in defaultlocalLobbySettings) {
-		// 								setLobbySettings(field, defaultlocalLobbySettings[field]);
-		// 							}
-		// 						}
-		// 					});
-		// 				}
-		// 			});
-		// 			connection.on('close', () => {
-		// 				console.log('Disconnected from', peer, 'Initiator:', initiator);
-		// 				disconnectPeer(peer);
-		// 			});
-		// 			connection.on('error', () => {
-		// 				console.log('ONERROR');
-		// 				/*empty*/
-		// 			});
-		// 			return connection;
-		// 		}
-
-		// 		socket.on('join', async (peer: string, client: Client) => {
-		// 			const oldSocketId = playerSocketIdsRef.current[client.clientId];
-		// 			if (oldSocketId && audioElements.current[oldSocketId]) {
-		// 				disconnectAudioElement(oldSocketId);
-		// 			}
-		// 			createPeerConnection(peer, true);
-		// 			setSocketClients((old) => ({ ...old, [peer]: client }));
-		// 		});
-
-		// 		socket.on('signal', ({ data, from }: { data: Peer.SignalData; from: string }) => {
-		// 			//console.log('onsignal', JSON.stringify(data));
-		// 			if (data.hasOwnProperty('mobilePlayerInfo')) {
-		// 				// eslint-disable-line
-		// 				const mobiledata = data as mobileHostInfo;
-		// 				if (
-		// 					mobiledata.mobilePlayerInfo.code === hostRef.current.code &&
-		// 					hostRef.current.gamestate !== GameState.MENU
-		// 				) {
-		// 					hostRef.current.mobileRunning = true;
-		// 					console.log('setting mobileRunning to true..');
-		// 				}
-		// 				return;
-		// 			}
-		// 			console.log('ONSIGNAL', data);
-		// 			let connection: Peer.Instance;
-		// 			if (!socketClientsRef.current[from]) {
-		// 				console.warn('SIGNAL FROM UNKOWN SOCKET..');
-		// 				return;
-		// 			}
-		// 			if (data.hasOwnProperty('type')) {
-		// 				// if (data.type === 'offer' && peerConnections[from]) {
-		// 				// 	console.log("Got offer with already a connection")
-		// 				// }
-		// 				if (peerConnections[from] && data.type !== 'offer') {
-		// 					console.log('Send to existing peer 1');
-		// 					connection = peerConnections[from];
-		// 				} else {
-		// 					console.log('Send to new peer 1');
-		// 					connection = createPeerConnection(from, false);
-		// 				}
-		// 				connection.signal(data);
-		// 			}
-		// 		});
-		// 	},
-		// 	(error) => {
-		// 		console.error(error);
-		// 		setError("Couldn't connect to your microphone:\n" + error);
-		// 		// ipcRenderer.send(IpcMessages.SHOW_ERROR_DIALOG, {
-		// 		// 	title: 'Error',
-		// 		// 	content: 'Couldn\'t connect to your microphone:\n' + error
-		// 		// });
-		// 	}
-		// );
 
 		return () => {
 			hostRef.current.mobileRunning = false;
@@ -1777,10 +1459,7 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 										}
 										size={50}
 										socketConfig={socketConfig}
-										onConfigChange={() => {
-											setSetting(`playerConfigMap.${player.nameHash}`, playerConfigs[player.nameHash]);
-											// store.set(`playerConfigMap.${player.nameHash}`, playerConfigs[player.nameHash]);
-										}}
+										onConfigChange={() => setSetting(`playerConfigMap.${player.nameHash}`, playerConfigs[player.nameHash])}
 										mod={gameState.mod}
 									/>
 								</Grid>

--- a/src/renderer/contexts.tsx
+++ b/src/renderer/contexts.tsx
@@ -2,6 +2,8 @@ import React, { createContext } from 'react';
 import { AmongUsState } from '../common/AmongUsState';
 import { ISettings, ILobbySettings } from '../common/ISettings';
 
+
+// TODO: Redo this entire file
 type SettingsContextValue = [
 	ISettings,
 	React.Dispatch<{

--- a/src/renderer/contexts.tsx
+++ b/src/renderer/contexts.tsx
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 import { AmongUsState } from '../common/AmongUsState';
-import { ISettings } from '../common/ISettings';
+import { ILobbySettings, ISettings } from '../common/ISettings';
 import { setSetting, setLobbySetting } from './settings/SettingsStore';
 
 
@@ -10,16 +10,10 @@ type SettingsContextValue = [
 	typeof setSetting,
 	typeof setLobbySetting
 ];
-// type LobbySettingsContextValue = [
-// 	ILobbySettings,
-// 	React.Dispatch<{
-// 		type: 'set' | 'setOne';
-// 		action: ILobbySettings | [string, unknown];
-// 	}>
-// ];
 
 export const PlayerColorContext = createContext<string[][]>([] as string[][]);
 export const GameStateContext = createContext<AmongUsState>({} as AmongUsState);
+export const HostSettingsContext = createContext<ILobbySettings>({} as ILobbySettings);
 export const SettingsContext = createContext<SettingsContextValue>((null as unknown) as SettingsContextValue);
 // export const LobbySettingsContext = createContext<LobbySettingsContextValue>(
 // 	(null as unknown) as LobbySettingsContextValue

--- a/src/renderer/contexts.tsx
+++ b/src/renderer/contexts.tsx
@@ -11,9 +11,14 @@ type SettingsContextValue = [
 	typeof setLobbySetting
 ];
 
+type HostSettingsContextValue = [
+	ILobbySettings,
+	React.Dispatch<React.SetStateAction<ILobbySettings>>
+];
+
 export const PlayerColorContext = createContext<string[][]>([] as string[][]);
 export const GameStateContext = createContext<AmongUsState>({} as AmongUsState);
-export const HostSettingsContext = createContext<ILobbySettings>({} as ILobbySettings);
+export const HostSettingsContext = createContext<HostSettingsContextValue>((null as unknown) as HostSettingsContextValue);
 export const SettingsContext = createContext<SettingsContextValue>((null as unknown) as SettingsContextValue);
 // export const LobbySettingsContext = createContext<LobbySettingsContextValue>(
 // 	(null as unknown) as LobbySettingsContextValue

--- a/src/renderer/contexts.tsx
+++ b/src/renderer/contexts.tsx
@@ -3,8 +3,6 @@ import { AmongUsState } from '../common/AmongUsState';
 import { ILobbySettings, ISettings } from '../common/ISettings';
 import { setSetting, setLobbySetting } from './settings/SettingsStore';
 
-
-// TODO: Redo this entire file
 type SettingsContextValue = [
 	ISettings,
 	typeof setSetting,
@@ -20,6 +18,3 @@ export const PlayerColorContext = createContext<string[][]>([] as string[][]);
 export const GameStateContext = createContext<AmongUsState>({} as AmongUsState);
 export const HostSettingsContext = createContext<HostSettingsContextValue>((null as unknown) as HostSettingsContextValue);
 export const SettingsContext = createContext<SettingsContextValue>((null as unknown) as SettingsContextValue);
-// export const LobbySettingsContext = createContext<LobbySettingsContextValue>(
-// 	(null as unknown) as LobbySettingsContextValue
-// );

--- a/src/renderer/contexts.tsx
+++ b/src/renderer/contexts.tsx
@@ -1,27 +1,26 @@
-import React, { createContext } from 'react';
+import { createContext } from 'react';
 import { AmongUsState } from '../common/AmongUsState';
-import { ISettings, ILobbySettings } from '../common/ISettings';
+import { ISettings } from '../common/ISettings';
+import { setSetting, setLobbySetting } from './settings/SettingsStore';
 
 
 // TODO: Redo this entire file
 type SettingsContextValue = [
 	ISettings,
-	React.Dispatch<{
-		type: 'set' | 'setOne' | 'setLobbySetting';
-		action: ISettings | [string, unknown];
-	}>
+	typeof setSetting,
+	typeof setLobbySetting
 ];
-type LobbySettingsContextValue = [
-	ILobbySettings,
-	React.Dispatch<{
-		type: 'set' | 'setOne';
-		action: ILobbySettings | [string, unknown];
-	}>
-];
+// type LobbySettingsContextValue = [
+// 	ILobbySettings,
+// 	React.Dispatch<{
+// 		type: 'set' | 'setOne';
+// 		action: ILobbySettings | [string, unknown];
+// 	}>
+// ];
 
 export const PlayerColorContext = createContext<string[][]>([] as string[][]);
 export const GameStateContext = createContext<AmongUsState>({} as AmongUsState);
 export const SettingsContext = createContext<SettingsContextValue>((null as unknown) as SettingsContextValue);
-export const LobbySettingsContext = createContext<LobbySettingsContextValue>(
-	(null as unknown) as LobbySettingsContextValue
-);
+// export const LobbySettingsContext = createContext<LobbySettingsContextValue>(
+// 	(null as unknown) as LobbySettingsContextValue
+// );

--- a/src/renderer/settings/CustomPlatformSettings.tsx
+++ b/src/renderer/settings/CustomPlatformSettings.tsx
@@ -122,36 +122,21 @@ export const CustomPlatformSettings: React.FC<CustomPlatformSettingProps> = func
 	const saveCustomPlatform = () => {
 		if (editPlatform && settings.customPlatforms[editPlatform.key]) {
 			const { [editPlatform.key]: remove, ...rest } = settings.customPlatforms;
-			setSettings({
-				type: 'setOne',
-				action: [
-					'customPlatforms',
-					{
-						...rest,
-						[customPlatform.key]: customPlatform,
-					},
-				],
+			setSettings('customPlatforms', {
+				...rest, 
+				[customPlatform.key]: customPlatform,
 			});
 		} else {
-			setSettings({
-				type: 'setOne',
-				action: [
-					'customPlatforms',
-					{
-						...settings.customPlatforms,
-						[customPlatform.key]: customPlatform,
-					},
-				],
+			setSettings('customPlatforms', {
+				...settings.customPlatforms,
+				[customPlatform.key]: customPlatform,
 			});
 		}
 	};
 
 	const deleteCustomPlatform = () => {
 		const { [customPlatform.key]: remove, ...rest } = settings.customPlatforms;
-		setSettings({
-			type: 'setOne',
-			action: ['customPlatforms', rest],
-		});
+		setSettings('customPlatforms', rest);
 	};
 
 	const runInputs = useMemo(() => {

--- a/src/renderer/settings/PublicLobbySettings.tsx
+++ b/src/renderer/settings/PublicLobbySettings.tsx
@@ -8,7 +8,7 @@ import ChevronLeft from '@material-ui/icons/ArrowBack';
 
 type publicLobbySettingProps = {
 	t: (key: string) => string;
-	updateSetting: (setting: string, newValue: any) => void;
+	updateSetting: <K extends keyof ILobbySettings>(setting: K, newValue: ILobbySettings[K]) => void;
 	lobbySettings: ILobbySettings;
 	canChange: boolean;
 	className: string;

--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -784,7 +784,7 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 								valueLabelDisplay="auto"
 								min={0}
 								max={300}
-								step={1}
+								step={2}
 								onChange={(_, newValue: number | number[]) => setSettings('microphoneGain', newValue as number)}
 								aria-labelledby="input-slider"
 							/>

--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -265,7 +265,7 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 		SettingsStore.clear();
 		// This is necessary for resetting hotkeys properly, the main thread needs to be notified to reset the hooks
 		ipcRenderer.send(IpcHandlerMessages.RESET_KEYHOOKS);
-		// TODO: Don't believe this is actually necessary?
+
 		location.reload();
 	};
 

--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -1,5 +1,5 @@
 import React, { ReactChild, useCallback, useContext, useEffect, useReducer, useState } from 'react';
-import { SettingsContext, /*LobbySettingsContext,*/ GameStateContext, HostSettingsContext } from '../contexts';
+import { SettingsContext, GameStateContext, HostSettingsContext } from '../contexts';
 import MicrophoneSoundBar from './MicrophoneSoundBar';
 import TestSpeakersButton from './TestSpeakersButton';
 import { ISettings, ILobbySettings } from '../../common/ISettings';
@@ -170,14 +170,10 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 	const [settings, setSettings, setLobbySettings] = useContext(SettingsContext);
 	const gameState = useContext(GameStateContext);
 	const [hostLobbySettings] = useContext(HostSettingsContext);
-	// const hostLobbySettings = settings.localLobbySettings;
 	const [unsavedCount, setUnsavedCount] = useState(0);
 	const unsaved = unsavedCount > 2;
 
 	const [myLocalLobbySettings, setMyLocalLobbySettings] = useState(settings.localLobbySettings);
-	// useEffect(() => {
-	// 	setMyLocalLobbySettings(settings.localLobbySettings);
-	// }, [settings.localLobbySettings]);
 
 	useEffect(() => {
 		setUnsavedCount((s) => s + 1);

--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -28,7 +28,7 @@ import languages from '../language/languages';
 import ServerURLInput from './ServerURLInput';
 import MuiDivider from '@material-ui/core/Divider';
 import PublicLobbySettings from './PublicLobbySettings';
-import { pushToTalkOptions } from './SettingsStore';
+import SettingsStore, { pushToTalkOptions } from './SettingsStore';
 
 interface StyleInput {
 	open: boolean;
@@ -261,19 +261,11 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 		}
 	};
 
-	// TODO: FIX THIS
 	const resetDefaults = () => {
-		// SettingsStore.clear();
-		// setSettings({
-		// 	type: 'set',
-		// 	action: SettingsStore.store,
-		// });
-
-		// I'm like 90% sure this isn't necessary but whenever you click the mic/speaker dropdown it is called, so it may be necessary
-		// updateDevices();
-
+		SettingsStore.clear();
 		// This is necessary for resetting hotkeys properly, the main thread needs to be notified to reset the hooks
 		ipcRenderer.send(IpcHandlerMessages.RESET_KEYHOOKS);
+		// TODO: Don't believe this is actually necessary?
 		location.reload();
 	};
 
@@ -1092,9 +1084,7 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 								openWarningDialog(
 									t('settings.warning'),
 									t('settings.troubleshooting.restore_warning'),
-									() => {
-										resetDefaults();
-									},
+									() => resetDefaults(),
 									true
 								)
 							}

--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -1,4 +1,3 @@
-import Store from 'electron-store';
 import React, { ReactChild, useCallback, useContext, useEffect, useReducer, useState } from 'react';
 import { SettingsContext, LobbySettingsContext, GameStateContext } from '../contexts';
 import MicrophoneSoundBar from './MicrophoneSoundBar';
@@ -29,7 +28,7 @@ import languages from '../language/languages';
 import ServerURLInput from './ServerURLInput';
 import MuiDivider from '@material-ui/core/Divider';
 import PublicLobbySettings from './PublicLobbySettings';
-import { GamePlatform } from '../../common/GamePlatform';
+import SettingsStore, { pushToTalkOptions } from './SettingsStore';
 
 interface StyleInput {
 	open: boolean;
@@ -131,365 +130,13 @@ const keys = new Set([
 	'LControl',
 ]);
 
-export enum pushToTalkOptions {
-	VOICE,
-	PUSH_TO_TALK,
-	PUSH_TO_MUTE,
-}
-
-const store = new Store<ISettings>({
-	migrations: {
-		'2.0.6': (store) => {
-			if (
-				store.get('serverURL') === 'http://bettercrewl.ink' ||
-				store.get('serverURL') === 'https://bettercrewlink.app' ||
-				store.get('serverURL') === 'http://bettercrewlink.app' ||
-				store.get('serverURL') === 'https://bettercrewlink.app/' ||
-				store.get('serverURL') === 'http://bettercrewlink.app/' ||
-				store.get('serverURL') === 'https://bettercrewl.ink:6523' ||
-				store.get('serverURL') === 'http://bettercrewl.ink:6523' ||
-				store.get('serverURL') === 'https://crewlink.guus.info' ||
-				store.get('serverURL') === 'http://crewlink.guus.info' ||
-				store.get('serverURL') === 'https://crewlink.guus.ninja' ||
-				store.get('serverURL') === 'http://crewlink.guus.ninja' ||
-				store.get('serverURL') === 'https://github.com/OhMyGuus/BetterCrewLink' ||
-				store.get('serverURL') === 'https://mirror.bettercrewl.ink' ||
-				store.get('serverURL') === 'https://mirror.bettercrewl.ink/' ||
-				store.get('serverURL') === 'https://www.curseforge.com/among-us/all-mods/bettercrewlink-proximity-chat' ||
-				store.get('serverURL') === 'https://matadorprobr.itch.io/bettercrewlink' ||
-				store.get('serverURL') === 'https://gamebanana.com/tools/7079' ||
-				store.get('serverURL') === 'https://web.bettercrewl.ink' ||
-				store.get('serverURL') === 'https://obs.bettercrewlink.app' ||
-				store.get('serverURL') === 'https://discord.gg/qDqTzvj4SH'
-			) {
-				store.set('serverURL', 'https://bettercrewl.ink');
-			}
-		},
-		'2.0.7': (store) => {
-			if (
-				store.get('serverURL') === 'http://bettercrewl.ink' ||
-				store.get('serverURL') === 'https://bettercrewlink.app' ||
-				store.get('serverURL') === 'http://bettercrewlink.app' ||
-				store.get('serverURL') === 'https://bettercrewlink.app/' ||
-				store.get('serverURL') === 'http://bettercrewlink.app/' ||
-				store.get('serverURL') === 'https://bettercrewl.ink:6523' ||
-				store.get('serverURL') === 'http://bettercrewl.ink:6523' ||
-				store.get('serverURL') === 'https://crewlink.guus.info' ||
-				store.get('serverURL') === 'http://crewlink.guus.info' ||
-				store.get('serverURL') === 'https://crewlink.guus.ninja' ||
-				store.get('serverURL') === 'http://crewlink.guus.ninja' ||
-				store.get('serverURL') === 'https://github.com/OhMyGuus/BetterCrewLink' ||
-				store.get('serverURL') === 'https://mirror.bettercrewl.ink' ||
-				store.get('serverURL') === 'https://mirror.bettercrewl.ink/' ||
-				store.get('serverURL') === 'https://www.curseforge.com/among-us/all-mods/bettercrewlink-proximity-chat' ||
-				store.get('serverURL') === 'https://matadorprobr.itch.io/bettercrewlink' ||
-				store.get('serverURL') === 'https://gamebanana.com/tools/7079' ||
-				store.get('serverURL') === 'https://web.bettercrewl.ink' ||
-				store.get('serverURL') === 'https://obs.bettercrewlink.app' ||
-				store.get('serverURL') === 'https://discord.gg/qDqTzvj4SH'
-			) {
-				store.set('serverURL', 'https://bettercrewl.ink');
-			}
-		},
-		'2.1.4': (store) => {
-			store.set('playerConfigMap', {});
-		},
-		'2.2.0': (store) => {
-			store.set('mobileHost', true);
-		},
-		'2.2.5': (store) => {
-			const pushToTalkValue = store.get('pushToTalk');
-			if (typeof pushToTalkValue === 'boolean') {
-				store.set('pushToTalkMode', pushToTalkValue ? pushToTalkOptions.PUSH_TO_TALK : pushToTalkOptions.VOICE);
-			}
-			// @ts-ignore
-			store.delete('pushToTalk');
-		},
-		'2.3.6': (store) => {
-			if ((store.get('serverURL') as string).includes('//crewl.ink')) store.set('serverURL', 'https://bettercrewl.ink');
-		},
-		'2.4.0': (store) => {
-			const currentSensitivity = store.get('micSensitivity') as number;
-			if (currentSensitivity >= 0.3) {
-				store.set('micSensitivity', 0.15);
-				store.set('micSensitivityEnabled', false);
-			}
-		},
-	},
-	schema: {
-		alwaysOnTop: {
-			type: 'boolean',
-			default: false,
-		},
-		language: {
-			type: 'string',
-			default: 'unkown',
-		},
-		microphone: {
-			type: 'string',
-			default: 'Default',
-		},
-		speaker: {
-			type: 'string',
-			default: 'Default',
-		},
-		pushToTalkMode: {
-			type: 'number',
-			default: pushToTalkOptions.VOICE,
-		},
-		serverURL: {
-			type: 'string',
-			default: 'https://bettercrewl.ink',
-			format: 'uri',
-		},
-		pushToTalkShortcut: {
-			type: 'string',
-			default: 'V',
-		},
-		deafenShortcut: {
-			type: 'string',
-			default: 'RControl',
-		},
-		impostorRadioShortcut: {
-			type: 'string',
-			default: 'F',
-		},
-		muteShortcut: {
-			type: 'string',
-			default: 'RAlt',
-		},
-		hideCode: {
-			type: 'boolean',
-			default: false,
-		},
-		compactOverlay: {
-			type: 'boolean',
-			default: false,
-		},
-		overlayPosition: {
-			type: 'string',
-			default: 'right',
-		},
-		meetingOverlay: {
-			type: 'boolean',
-			default: true,
-		},
-		enableOverlay: {
-			type: 'boolean',
-			default: true,
-		},
-		ghostVolume: {
-			type: 'number',
-			default: 100,
-		},
-		masterVolume: {
-			type: 'number',
-			default: 100,
-		},
-		microphoneGain: {
-			type: 'number',
-			default: 100,
-		},
-		microphoneGainEnabled: {
-			type: 'boolean',
-			default: false,
-		},
-		micSensitivity: {
-			type: 'number',
-			default: 0.15,
-		},
-		micSensitivityEnabled: {
-			type: 'boolean',
-			default: false,
-		},
-		natFix: {
-			type: 'boolean',
-			default: false,
-		},
-		mobileHost: {
-			type: 'boolean',
-			default: true,
-		},
-		vadEnabled: {
-			type: 'boolean',
-			default: true,
-		},
-		hardware_acceleration: {
-			type: 'boolean',
-			default: true,
-		},
-		enableSpatialAudio: {
-			type: 'boolean',
-			default: true,
-		},
-		obsSecret: {
-			type: 'string',
-			default: undefined,
-		},
-
-		obsOverlay: {
-			type: 'boolean',
-			default: false,
-		},
-		echoCancellation: {
-			type: 'boolean',
-			default: true,
-		},
-		noiseSuppression: {
-			type: 'boolean',
-			default: true,
-		},
-		oldSampleDebug: {
-			type: 'boolean', 
-			default: false,
-		},
-		playerConfigMap: {
-			type: 'object',
-			default: {},
-			additionalProperties: {
-				type: 'object',
-				properties: {
-					volume: {
-						type: 'number',
-						default: 1,
-					},
-					isMuted: {
-						type: 'boolean',
-						default: false,
-					},
-				},
-			},
-		},
-		localLobbySettings: {
-			type: 'object',
-			properties: {
-				maxDistance: {
-					type: 'number',
-					default: 5.32,
-				},
-				haunting: {
-					type: 'boolean',
-					default: false,
-				},
-				commsSabotage: {
-					type: 'boolean',
-					default: false,
-				},
-				hearImpostorsInVents: {
-					type: 'boolean',
-					default: false,
-				},
-				impostersHearImpostersInvent: {
-					type: 'boolean',
-					default: false,
-				},
-				impostorRadioEnabled: {
-					type: 'boolean',
-					default: false,
-				},
-				deadOnly: {
-					type: 'boolean',
-					default: false,
-				},
-				meetingGhostOnly: {
-					type: 'boolean',
-					default: false,
-				},
-				visionHearing: {
-					type: 'boolean',
-					default: false,
-				},
-				hearThroughCameras: {
-					type: 'boolean',
-					default: false,
-				},
-				wallsBlockAudio: {
-					type: 'boolean',
-					default: false,
-				},
-				publicLobby_on: {
-					type: 'boolean',
-					default: false,
-				},
-				publicLobby_title: {
-					type: 'string',
-					default: '',
-				},
-				publicLobby_language: {
-					type: 'string',
-					default: 'en',
-				},
-				publicLobby_mods: {
-					type: 'string',
-					default: 'NONE',
-				},
-			},
-			default: {
-				maxDistance: 5.32,
-				haunting: false,
-				commsSabotage: false,
-				hearImpostorsInVents: false,
-				hearThroughCameras: false,
-				wallsBlockAudio: false,
-				deadOnly: false,
-				meetingGhostOnly: false,
-				visionHearing: false,
-				publicLobby_on: false,
-				publicLobby_title: '',
-				publicLobby_language: 'en',
-				publicLobby_mods: 'NONE',
-			},
-		},
-		launchPlatform: {
-			type: 'string',
-			default: GamePlatform.STEAM,
-		},
-		customPlatforms: {
-			type: 'object',
-			default: {},
-			additionalProperties: {
-				type: 'object',
-				properties: {
-					default: {
-						type: 'boolean',
-						default: false,
-					},
-					key: {
-						type: 'string',
-						default: '',
-					},
-					launchType: {
-						type: 'string',
-						default: 'EXE',
-					},
-					runPath: {
-						type: 'string',
-						default: '',
-					},
-					execute: {
-						type: 'array',
-						default: [''],
-						items: {
-							type: 'string',
-							default: '',
-						},
-					},
-					translateKey: {
-						type: 'string',
-						default: '',
-					},
-				},
-			},
-		},
-	},
-});
-
 export interface SettingsProps {
 	t: TFunction;
 	open: boolean;
 	onClose: () => void;
 }
 
+// TODO: Remove
 export const settingsReducer = (
 	state: ISettings,
 	action: {
@@ -509,13 +156,14 @@ export const settingsReducer = (
 		v[0] = 'localLobbySettings';
 		v[1] = lobbySettings;
 	}
-	store.set(v[0], v[1]);
+	SettingsStore.set(v[0], v[1]);
 	return {
 		...state,
 		[v[0]]: v[1],
 	};
 };
 
+// TODO: Remove
 export const lobbySettingsReducer = (
 	state: ILobbySettings,
 	action: {
@@ -567,16 +215,6 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 	const [lobbySettings, setLobbySettings] = useContext(LobbySettingsContext);
 	const [unsavedCount, setUnsavedCount] = useState(0);
 	const unsaved = unsavedCount > 2;
-	useEffect(() => {
-		setSettings({
-			type: 'set',
-			action: store.store,
-		});
-		setLobbySettings({
-			type: 'set',
-			action: store.get('localLobbySettings'),
-		});
-	}, []);
 
 	useEffect(() => {
 		setUnsavedCount((s) => s + 1);
@@ -669,10 +307,10 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 	};
 
 	const resetDefaults = () => {
-		store.clear();
+		SettingsStore.clear();
 		setSettings({
 			type: 'set',
-			action: store.store,
+			action: SettingsStore.store,
 		});
 
 		// I'm like 90% sure this isn't necessary but whenever you click the mic/speaker dropdown it is called, so it may be necessary

--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -1001,10 +1001,7 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 								t('settings.warning'),
 								t('settings.beta.oldsampledebug_warning'),
 								() => {
-									setSettings({
-										type: 'setOne',
-										action: ['oldSampleDebug', checked],
-									});
+									setSettings('oldSampleDebug', checked);
 								},
 								checked
 							);

--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -1,5 +1,5 @@
 import React, { ReactChild, useCallback, useContext, useEffect, useReducer, useState } from 'react';
-import { SettingsContext, /*LobbySettingsContext,*/ GameStateContext } from '../contexts';
+import { SettingsContext, /*LobbySettingsContext,*/ GameStateContext, HostSettingsContext } from '../contexts';
 import MicrophoneSoundBar from './MicrophoneSoundBar';
 import TestSpeakersButton from './TestSpeakersButton';
 import { ISettings, ILobbySettings } from '../../common/ISettings';
@@ -169,8 +169,8 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 	const classes = useStyles({ open });
 	const [settings, setSettings, setLobbySettings] = useContext(SettingsContext);
 	const gameState = useContext(GameStateContext);
-	// const [lobbySettings] = useContext(LobbySettingsContext);
-	const hostLobbySettings = settings.localLobbySettings;
+	const [hostLobbySettings] = useContext(HostSettingsContext);
+	// const hostLobbySettings = settings.localLobbySettings;
 	const [unsavedCount, setUnsavedCount] = useState(0);
 	const unsaved = unsavedCount > 2;
 

--- a/src/renderer/settings/SettingsStore.tsx
+++ b/src/renderer/settings/SettingsStore.tsx
@@ -355,7 +355,7 @@ export const SettingsStore = new Store<ISettings>({
 type ISettingOrSocketConfig<K extends keyof ISettings | `playerConfigMap.${number}`> = K extends keyof ISettings ? ISettings[K] : SocketConfig;
 
 // If our setting is a keyof ISettings, value is the appropriate type. If setting is `playerConfigMap.1234` then value is a socket config
-export const setSetting = <K extends keyof ISettings | `playerConfigMap.${number}`>(setting: K, value: ISettingOrSocketConfig<K>) => {
+export const setSetting = <K extends (keyof ISettings | `playerConfigMap.${number}`)>(setting: K, value: ISettingOrSocketConfig<K>) => {
 	SettingsStore.set(setting, value)
 };
 

--- a/src/renderer/settings/SettingsStore.tsx
+++ b/src/renderer/settings/SettingsStore.tsx
@@ -1,6 +1,6 @@
 import Store from 'electron-store';
 import { GamePlatform } from '../../common/GamePlatform';
-import { ISettings } from '../../common/ISettings';
+import { ILobbySettings, ISettings } from '../../common/ISettings';
 
 export enum pushToTalkOptions {
 	VOICE,
@@ -350,5 +350,15 @@ export const SettingsStore = new Store<ISettings>({
 		},
 	},
 });
+
+// Set a setting
+
+export const setSetting = <K extends keyof ISettings>(setting: K, value: ISettings[K]) => {
+	SettingsStore.set(setting, value)
+};
+
+export const setLobbySetting = <K extends keyof ILobbySettings>(setting: K, value: ILobbySettings[K]) => {
+	SettingsStore.set(`localLobbySettings.${setting}`, value);
+};
 
 export default SettingsStore;

--- a/src/renderer/settings/SettingsStore.tsx
+++ b/src/renderer/settings/SettingsStore.tsx
@@ -356,7 +356,7 @@ type ISettingOrSocketConfig<K extends keyof ISettings | `playerConfigMap.${numbe
 
 // If our setting is a keyof ISettings, value is the appropriate type. If setting is `playerConfigMap.1234` then value is a socket config
 export const setSetting = <K extends (keyof ISettings | `playerConfigMap.${number}`)>(setting: K, value: ISettingOrSocketConfig<K>) => {
-	SettingsStore.set(setting, value)
+	SettingsStore.set(setting, value);
 };
 
 export const setLobbySetting = <K extends keyof ILobbySettings>(setting: K, value: ILobbySettings[K]) => {

--- a/src/renderer/settings/SettingsStore.tsx
+++ b/src/renderer/settings/SettingsStore.tsx
@@ -1,6 +1,6 @@
 import Store from 'electron-store';
 import { GamePlatform } from '../../common/GamePlatform';
-import { ILobbySettings, ISettings } from '../../common/ISettings';
+import { ILobbySettings, ISettings, SocketConfig } from '../../common/ISettings';
 
 export enum pushToTalkOptions {
 	VOICE,
@@ -351,9 +351,11 @@ export const SettingsStore = new Store<ISettings>({
 	},
 });
 
-// Set a setting
+// This is fricken weird but also great
+type ISettingOrSocketConfig<K extends keyof ISettings | `playerConfigMap.${number}`> = K extends keyof ISettings ? ISettings[K] : SocketConfig;
 
-export const setSetting = <K extends keyof ISettings>(setting: K, value: ISettings[K]) => {
+// If our setting is a keyof ISettings, value is the appropriate type. If setting is `playerConfigMap.1234` then value is a socket config
+export const setSetting = <K extends keyof ISettings | `playerConfigMap.${number}`>(setting: K, value: ISettingOrSocketConfig<K>) => {
 	SettingsStore.set(setting, value)
 };
 

--- a/src/renderer/settings/SettingsStore.tsx
+++ b/src/renderer/settings/SettingsStore.tsx
@@ -1,0 +1,354 @@
+import Store from 'electron-store';
+import { GamePlatform } from '../../common/GamePlatform';
+import { ISettings } from '../../common/ISettings';
+
+export enum pushToTalkOptions {
+	VOICE,
+	PUSH_TO_TALK,
+	PUSH_TO_MUTE,
+}
+
+export const SettingsStore = new Store<ISettings>({
+	migrations: {
+		'2.0.6': (store) => {
+			if (
+				store.get('serverURL') === 'http://bettercrewl.ink' ||
+				store.get('serverURL') === 'https://bettercrewlink.app' ||
+				store.get('serverURL') === 'http://bettercrewlink.app' ||
+				store.get('serverURL') === 'https://bettercrewlink.app/' ||
+				store.get('serverURL') === 'http://bettercrewlink.app/' ||
+				store.get('serverURL') === 'https://bettercrewl.ink:6523' ||
+				store.get('serverURL') === 'http://bettercrewl.ink:6523' ||
+				store.get('serverURL') === 'https://crewlink.guus.info' ||
+				store.get('serverURL') === 'http://crewlink.guus.info' ||
+				store.get('serverURL') === 'https://crewlink.guus.ninja' ||
+				store.get('serverURL') === 'http://crewlink.guus.ninja' ||
+				store.get('serverURL') === 'https://github.com/OhMyGuus/BetterCrewLink' ||
+				store.get('serverURL') === 'https://mirror.bettercrewl.ink' ||
+				store.get('serverURL') === 'https://mirror.bettercrewl.ink/' ||
+				store.get('serverURL') === 'https://www.curseforge.com/among-us/all-mods/bettercrewlink-proximity-chat' ||
+				store.get('serverURL') === 'https://matadorprobr.itch.io/bettercrewlink' ||
+				store.get('serverURL') === 'https://gamebanana.com/tools/7079' ||
+				store.get('serverURL') === 'https://web.bettercrewl.ink' ||
+				store.get('serverURL') === 'https://obs.bettercrewlink.app' ||
+				store.get('serverURL') === 'https://discord.gg/qDqTzvj4SH'
+			) {
+				store.set('serverURL', 'https://bettercrewl.ink');
+			}
+		},
+		'2.0.7': (store) => {
+			if (
+				store.get('serverURL') === 'http://bettercrewl.ink' ||
+				store.get('serverURL') === 'https://bettercrewlink.app' ||
+				store.get('serverURL') === 'http://bettercrewlink.app' ||
+				store.get('serverURL') === 'https://bettercrewlink.app/' ||
+				store.get('serverURL') === 'http://bettercrewlink.app/' ||
+				store.get('serverURL') === 'https://bettercrewl.ink:6523' ||
+				store.get('serverURL') === 'http://bettercrewl.ink:6523' ||
+				store.get('serverURL') === 'https://crewlink.guus.info' ||
+				store.get('serverURL') === 'http://crewlink.guus.info' ||
+				store.get('serverURL') === 'https://crewlink.guus.ninja' ||
+				store.get('serverURL') === 'http://crewlink.guus.ninja' ||
+				store.get('serverURL') === 'https://github.com/OhMyGuus/BetterCrewLink' ||
+				store.get('serverURL') === 'https://mirror.bettercrewl.ink' ||
+				store.get('serverURL') === 'https://mirror.bettercrewl.ink/' ||
+				store.get('serverURL') === 'https://www.curseforge.com/among-us/all-mods/bettercrewlink-proximity-chat' ||
+				store.get('serverURL') === 'https://matadorprobr.itch.io/bettercrewlink' ||
+				store.get('serverURL') === 'https://gamebanana.com/tools/7079' ||
+				store.get('serverURL') === 'https://web.bettercrewl.ink' ||
+				store.get('serverURL') === 'https://obs.bettercrewlink.app' ||
+				store.get('serverURL') === 'https://discord.gg/qDqTzvj4SH'
+			) {
+				store.set('serverURL', 'https://bettercrewl.ink');
+			}
+		},
+		'2.1.4': (store) => {
+			store.set('playerConfigMap', {});
+		},
+		'2.2.0': (store) => {
+			store.set('mobileHost', true);
+		},
+		'2.2.5': (store) => {
+			const pushToTalkValue = store.get('pushToTalk');
+			if (typeof pushToTalkValue === 'boolean') {
+				store.set('pushToTalkMode', pushToTalkValue ? pushToTalkOptions.PUSH_TO_TALK : pushToTalkOptions.VOICE);
+			}
+			// @ts-ignore
+			store.delete('pushToTalk');
+		},
+		'2.3.6': (store) => {
+			if ((store.get('serverURL') as string).includes('//crewl.ink')) store.set('serverURL', 'https://bettercrewl.ink');
+		},
+		'2.4.0': (store) => {
+			const currentSensitivity = store.get('micSensitivity') as number;
+			if (currentSensitivity >= 0.3) {
+				store.set('micSensitivity', 0.15);
+				store.set('micSensitivityEnabled', false);
+			}
+		},
+	},
+	schema: {
+		alwaysOnTop: {
+			type: 'boolean',
+			default: false,
+		},
+		language: {
+			type: 'string',
+			default: 'unkown',
+		},
+		microphone: {
+			type: 'string',
+			default: 'Default',
+		},
+		speaker: {
+			type: 'string',
+			default: 'Default',
+		},
+		pushToTalkMode: {
+			type: 'number',
+			default: pushToTalkOptions.VOICE,
+		},
+		serverURL: {
+			type: 'string',
+			default: 'https://bettercrewl.ink',
+			format: 'uri',
+		},
+		pushToTalkShortcut: {
+			type: 'string',
+			default: 'V',
+		},
+		deafenShortcut: {
+			type: 'string',
+			default: 'RControl',
+		},
+		impostorRadioShortcut: {
+			type: 'string',
+			default: 'F',
+		},
+		muteShortcut: {
+			type: 'string',
+			default: 'RAlt',
+		},
+		hideCode: {
+			type: 'boolean',
+			default: false,
+		},
+		compactOverlay: {
+			type: 'boolean',
+			default: false,
+		},
+		overlayPosition: {
+			type: 'string',
+			default: 'right',
+		},
+		meetingOverlay: {
+			type: 'boolean',
+			default: true,
+		},
+		enableOverlay: {
+			type: 'boolean',
+			default: true,
+		},
+		ghostVolume: {
+			type: 'number',
+			default: 100,
+		},
+		masterVolume: {
+			type: 'number',
+			default: 100,
+		},
+		microphoneGain: {
+			type: 'number',
+			default: 100,
+		},
+		microphoneGainEnabled: {
+			type: 'boolean',
+			default: false,
+		},
+		micSensitivity: {
+			type: 'number',
+			default: 0.15,
+		},
+		micSensitivityEnabled: {
+			type: 'boolean',
+			default: false,
+		},
+		natFix: {
+			type: 'boolean',
+			default: false,
+		},
+		mobileHost: {
+			type: 'boolean',
+			default: true,
+		},
+		vadEnabled: {
+			type: 'boolean',
+			default: true,
+		},
+		hardware_acceleration: {
+			type: 'boolean',
+			default: true,
+		},
+		enableSpatialAudio: {
+			type: 'boolean',
+			default: true,
+		},
+		obsSecret: {
+			type: 'string',
+			default: undefined,
+		},
+
+		obsOverlay: {
+			type: 'boolean',
+			default: false,
+		},
+		echoCancellation: {
+			type: 'boolean',
+			default: true,
+		},
+		noiseSuppression: {
+			type: 'boolean',
+			default: true,
+		},
+		playerConfigMap: {
+			type: 'object',
+			default: {},
+			additionalProperties: {
+				type: 'object',
+				properties: {
+					volume: {
+						type: 'number',
+						default: 1,
+					},
+					isMuted: {
+						type: 'boolean',
+						default: false,
+					},
+				},
+			},
+		},
+		localLobbySettings: {
+			type: 'object',
+			properties: {
+				maxDistance: {
+					type: 'number',
+					default: 5.32,
+				},
+				haunting: {
+					type: 'boolean',
+					default: false,
+				},
+				commsSabotage: {
+					type: 'boolean',
+					default: false,
+				},
+				hearImpostorsInVents: {
+					type: 'boolean',
+					default: false,
+				},
+				impostersHearImpostersInvent: {
+					type: 'boolean',
+					default: false,
+				},
+				impostorRadioEnabled: {
+					type: 'boolean',
+					default: false,
+				},
+				deadOnly: {
+					type: 'boolean',
+					default: false,
+				},
+				meetingGhostOnly: {
+					type: 'boolean',
+					default: false,
+				},
+				visionHearing: {
+					type: 'boolean',
+					default: false,
+				},
+				hearThroughCameras: {
+					type: 'boolean',
+					default: false,
+				},
+				wallsBlockAudio: {
+					type: 'boolean',
+					default: false,
+				},
+				publicLobby_on: {
+					type: 'boolean',
+					default: false,
+				},
+				publicLobby_title: {
+					type: 'string',
+					default: '',
+				},
+				publicLobby_language: {
+					type: 'string',
+					default: 'en',
+				},
+				publicLobby_mods: {
+					type: 'string',
+					default: 'NONE',
+				},
+			},
+			default: {
+				maxDistance: 5.32,
+				haunting: false,
+				commsSabotage: false,
+				hearImpostorsInVents: false,
+				hearThroughCameras: false,
+				wallsBlockAudio: false,
+				deadOnly: false,
+				meetingGhostOnly: false,
+				visionHearing: false,
+				publicLobby_on: false,
+				publicLobby_title: '',
+				publicLobby_language: 'en',
+				publicLobby_mods: 'NONE',
+			},
+		},
+		launchPlatform: {
+			type: 'string',
+			default: GamePlatform.STEAM,
+		},
+		customPlatforms: {
+			type: 'object',
+			default: {},
+			additionalProperties: {
+				type: 'object',
+				properties: {
+					default: {
+						type: 'boolean',
+						default: false,
+					},
+					key: {
+						type: 'string',
+						default: '',
+					},
+					launchType: {
+						type: 'string',
+						default: 'EXE',
+					},
+					runPath: {
+						type: 'string',
+						default: '',
+					},
+					execute: {
+						type: 'array',
+						default: [''],
+						items: {
+							type: 'string',
+							default: '',
+						},
+					},
+					translateKey: {
+						type: 'string',
+						default: '',
+					},
+				},
+			},
+		},
+	},
+});
+
+export default SettingsStore;

--- a/src/renderer/settings/SettingsStore.tsx
+++ b/src/renderer/settings/SettingsStore.tsx
@@ -210,6 +210,10 @@ export const SettingsStore = new Store<ISettings>({
 			type: 'boolean',
 			default: true,
 		},
+		oldSampleDebug: {
+			type: 'boolean',
+			default: false,
+		},
 		playerConfigMap: {
 			type: 'object',
 			default: {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -9781,7 +9781,7 @@ typeface-varela@^1.1.13:
   resolved "https://registry.yarnpkg.com/typeface-varela/-/typeface-varela-1.1.13.tgz#84e0dffa8c89238620f442eff65ba31df7b99314"
   integrity sha512-XEvac3alsCr2KwmePAXrVLXAiyF5obOz1xWShUgomYggsWD9swmhWB3lC88gtASsU0bkVS5JIFc7L7xKpCp7Mg==
 
-typescript@4.x.x, typescript@^4.0.3:
+typescript@4.x.x:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
@@ -9790,6 +9790,11 @@ typescript@^3.9.3:
   version "3.9.9"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
   integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
+
+typescript@^4.1:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
 unbox-primitive@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Settings are done in an overly-complicated way. This PR aims to move them to a much simpler solution.

Known TODO:

- [x] `App.tsx` move from a reducer to a normal state
- [x] `contexts.tsx` redo file to allow for a normal state
- [x] `Voice.tsx` check if we really need a unique store reference
- [x] `LobbyBrowser.tsx` check if we really need a unique store reference
- [x] `Settings.tsx` everything
- [x] `Settings.tsx` fix restore default settings button
- [x] `Settings.tsx` investigate removing reload on restore default settings
- [x] `Settings.tsx` investigate getting rid of reload on multiple settings edited
- [x] Clean up comments and logs
- [x] Rebase onto 3.0.1