### PR TITLE
Fixed error crashing BCL when github is down and ask to update

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -224,11 +224,13 @@ const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
 	app.quit();
 } else {
+	autoUpdater.autoDownload = false;
 	autoUpdater.checkForUpdates();
-	autoUpdater.on('update-available', () => {
+	autoUpdater.on('update-available', (info: UpdateInfo) => {
 		try {
 			global.mainWindow?.webContents.send(IpcRendererMessages.AUTO_UPDATER_STATE, {
 				state: 'available',
+				info: info,
 			});
 		} catch (e) {
 			/* Empty block */
@@ -254,15 +256,8 @@ if (!gotTheLock) {
 			/*empty*/
 		}
 	});
-	autoUpdater.on('update-downloaded', (info: UpdateInfo) => {
-		try {
-			global.mainWindow?.webContents.send(IpcRendererMessages.AUTO_UPDATER_STATE, {
-				state: 'downloaded',
-				info,
-			});
-		} catch (e) {
-			/*empty*/
-		}
+	autoUpdater.on('update-downloaded', () => {
+		autoUpdater.quitAndInstall();
 	});
 
 	// quit application when all windows are closed
@@ -335,7 +330,7 @@ if (!gotTheLock) {
 	});
 
 	ipcMain.on('update-app', () => {
-		autoUpdater.quitAndInstall();
+		autoUpdater.downloadUpdate();
 	});
 
 	ipcMain.on(IpcHandlerMessages.OPEN_LOBBYBROWSER, () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,7 +1,7 @@
 import React, { Dispatch, SetStateAction, useEffect, useState, useRef } from 'react';
 import Voice from './Voice';
 import Menu from './Menu';
-import { ipcRenderer } from 'electron';
+import { ipcRenderer, shell } from 'electron';
 import { AmongUsState } from '../common/AmongUsState';
 import Settings from './settings/Settings';
 import SettingsStore, { setSetting, setLobbySetting} from './settings/SettingsStore';
@@ -226,8 +226,11 @@ export default function App({ t }): JSX.Element {
 							<TitleBar settingsOpen={settingsOpen} setSettingsOpen={setSettingsOpen} />
 							<Settings t={t} open={settingsOpen} onClose={() => setSettingsOpen(false)} />
 							<Dialog fullWidth open={updaterState.state !== 'unavailable' && diaOpen}>
-								{updaterState.state === 'downloaded' && updaterState.info && (
+								{updaterState.state === 'available' && updaterState.info && (
 									<DialogTitle>Update v{updaterState.info.version}</DialogTitle>
+								)}
+								{updaterState.state === 'error' && (
+									<DialogTitle>Updater Error</DialogTitle>
 								)}
 								{updaterState.state === 'downloading' && <DialogTitle>Updating...</DialogTitle>}
 								<DialogContent>
@@ -239,22 +242,35 @@ export default function App({ t }): JSX.Element {
 											</DialogContentText>
 										</>
 									)}
-									{updaterState.state === 'downloaded' && (
+									{updaterState.state === 'available' && (
 										<>
 											<LinearProgress variant={'indeterminate'} />
-											<DialogContentText>Restart now or later?</DialogContentText>
+											<DialogContentText>Update now or later?</DialogContentText>
 										</>
 									)}
 									{updaterState.state === 'error' && (
-										<DialogContentText color="error">{updaterState.error}</DialogContentText>
+										<DialogContentText color="error">{String(updaterState.error)}</DialogContentText>
 									)}
 								</DialogContent>
 								{updaterState.state === 'error' && (
 									<DialogActions>
-										<Button href="https://github.com/OhMyGuus/BetterCrewLink/releases/latest">Download Manually</Button>
+										<Button 
+											onClick={() => {
+												shell.openExternal("https://github.com/OhMyGuus/BetterCrewLink/releases/latest");
+											}}
+										>
+											Download Manually
+										</Button>
+										<Button
+											onClick={() => {
+												setDiaOpen(false);
+											}}
+											>
+												Skip
+										</Button>
 									</DialogActions>
 								)}
-								{updaterState.state === 'downloaded' && (
+								{updaterState.state === 'available' && (
 									<DialogActions>
 										<Button
 											onClick={() => {


### PR DESCRIPTION
Mostly closes #283, still has issue with offsets from github not working if github is down.

To simulate Github being down:
Edit `C:\Windows\System32\drivers\etc\hosts` to include `127.0.0.1 github.com` and run `ipconfig /flushdns`
To undo:
Remove `127.0.0.1 github.com` from hosts file, run `ipconfig /flushdns`