### PR TITLE
Impostor Radio & PushToTalk Compatability

### DIFF
--- a/src/main/hook.ts
+++ b/src/main/hook.ts
@@ -67,6 +67,7 @@ ipcMain.handle(IpcHandlerMessages.START_HOOK, async (event) => {
 				event.sender.send(IpcRendererMessages.PUSH_TO_TALK, true);
 			}
 			if (keyCodeMatches(impostorRadioShortcut!, keyId)) {
+				event.sender.send(IpcRendererMessages.PUSH_TO_TALK, true);
 				event.sender.send(IpcRendererMessages.IMPOSTOR_RADIO, true);
 			}
 		});
@@ -82,6 +83,7 @@ ipcMain.handle(IpcHandlerMessages.START_HOOK, async (event) => {
 				event.sender.send(IpcRendererMessages.TOGGLE_MUTE);
 			}
 			if (keyCodeMatches(impostorRadioShortcut!, keyId)) {
+				event.sender.send(IpcRendererMessages.PUSH_TO_TALK, false);
 				event.sender.send(IpcRendererMessages.IMPOSTOR_RADIO, false);
 			}
 		});


### PR DESCRIPTION
I don't actually have the setup to test this at the moment but I believe currently radio & push to talk requires two buttons at once. This should make it so that just holding the radio button works.