### PR TITLE
[Offsets] Change ```githubusercontent``` to ```jsdelivr.net```

### DIFF
--- a/src/main/offsetStore.ts
+++ b/src/main/offsetStore.ts
@@ -134,14 +134,14 @@ interface IOffsetsStore {
 	offsets: IOffsets;
 }
 
-const BASE_URL = "https://raw.githubusercontent.com/OhMyGuus/BetterCrewlink-Offsets/main";
+const BASE_URL = "https://cdn.jsdelivr.net/gh/OhMyGuus/BetterCrewlink-Offsets@main/";
 
 const store = new Store<IOffsetsStore>({name: "offsets"});
 const lookupStore = new Store<IOffsetsLookup>({name: "lookup"});
 
 async function fetchOffsetLookupJson(): Promise<IOffsetsLookup> {
 	console.log(`Fetching lookup file`);
-	return fetch(`${BASE_URL}/lookup.json`)
+	return fetch(`${BASE_URL}lookup.json`)
 		.then((response) => response.json())
 		.then((data) => { return data as IOffsetsLookup })
 		.catch((_) => { throw Errors.LOOKUP_FETCH_ERROR })
@@ -159,7 +159,7 @@ export async function fetchOffsetLookup(): Promise<IOffsetsLookup> {
 	}
 }
 
-const OFFSETS_URL = `${BASE_URL}/offsets`;
+const OFFSETS_URL = `${BASE_URL}offsets`;
 async function fetchOffsetsJson(is_64bit: boolean, filename: string): Promise<IOffsets> {
 	console.log(`Fetching file: ${filename}`);
 	return fetch(`${OFFSETS_URL}/${is_64bit ? 'x64' : 'x86'}/${filename}`)


### PR DESCRIPTION
It will be more fast to reach the offsets since they have CDN's servers around the world and check what is the best CDN for the user, ~~will make users of China and other locations that block GitHub be able to use BCL again~~
> Investigating and it seems to not be working anymore on China because the ICP license was revoked but they plan on trying to recovery this license

For default they will use their server that is hosted on Germany that saves the cache temporary, if this server goes down or is missing from the local cache, it will use their AWS server that have all the files hosted and if the AWS server goes down, it will use GitHub to fetch the files

Every time a ping is made to a repository that is hosted on their server, they will check GitHub to see if there are any changes to the files so it shouldn't have outdated files

Also it shouldn't have much downtime since they use 2 DNS servers so if one goes down, it will use another and etc

More information about it here: https://www.jsdelivr.com/network/infographic