### PR TITLE
Updated mods and lobbybrowser display

### DIFF
--- a/src/common/Mods.ts
+++ b/src/common/Mods.ts
@@ -19,7 +19,7 @@ export const modList: AmongusMod[] = [
 	},
 	{
 		id: 'TOWN_OF_US',
-		label: 'Town of Us',
+		label: 'Town of Us: Reactivated',
 		dllStartsWith: 'TownOfUs',
 	},
 	{

--- a/src/common/Mods.ts
+++ b/src/common/Mods.ts
@@ -2,6 +2,7 @@ export type ModsType =
 	| 'NONE'
 	| 'TOWN_OF_US'
 	| 'THE_OTHER_ROLES'
+	| 'LAS_MONJAS'
 	| 'OTHER';
 
 export interface AmongusMod {
@@ -25,6 +26,11 @@ export const modList: AmongusMod[] = [
 		id: 'THE_OTHER_ROLES',
 		label: 'The Other Roles',
 		dllStartsWith: 'TheOtherRoles',
+	},
+	{
+		id: 'LAS_MONJAS',
+		label: 'Las Monjas',
+		dllStartsWith: 'LasMonjas',
 	},
 	{
 		id: 'OTHER',

--- a/src/renderer/LobbyBrowser/LobbyBrowser.tsx
+++ b/src/renderer/LobbyBrowser/LobbyBrowser.tsx
@@ -187,7 +187,7 @@ export default function lobbyBrowser({ t }) {
 												{row.current_players}/{row.max_players}
 											</StyledTableCell>
 											<StyledTableCell align="left">
-												{modList.find((o) => o.id === row.mods)?.label ?? 'None'}
+												{modList.find((o) => o.id === row.mods)?.label || (row.mods ?? 'None')}
 											</StyledTableCell>
 											<StyledTableCell align="left">
 												{(languages as any)[row.language]?.name ?? 'English'}


### PR DESCRIPTION
Now falls back to the raw mod id (eg TOWN_OF_US) before falling back to "None" for the listed mods