### PR TITLE
Fixed bug where non-impostors could use radio as PTT

### DIFF
--- a/src/main/hook.ts
+++ b/src/main/hook.ts
@@ -67,7 +67,7 @@ ipcMain.handle(IpcHandlerMessages.START_HOOK, async (event) => {
 			if (keyCodeMatches(pushToTalkShortcut!, keyId)) {
 				speaking += 1;
 			}
-			if (keyCodeMatches(impostorRadioShortcut!, keyId)) {
+			if (keyCodeMatches(impostorRadioShortcut!, keyId) && gameReader.lastState.players.find((value) => {return value.clientId === gameReader.lastState.clientId})?.isImpostor) {
 				speaking += 1;
 				event.sender.send(IpcRendererMessages.IMPOSTOR_RADIO, true);
 			}
@@ -91,7 +91,7 @@ ipcMain.handle(IpcHandlerMessages.START_HOOK, async (event) => {
 			if (keyCodeMatches(muteShortcut!, keyId)) {
 				event.sender.send(IpcRendererMessages.TOGGLE_MUTE);
 			}
-			if (keyCodeMatches(impostorRadioShortcut!, keyId)) {
+			if (keyCodeMatches(impostorRadioShortcut!, keyId) && gameReader.lastState.players.find((value) => {return value.clientId === gameReader.lastState.clientId})?.isImpostor) {
 				speaking -= 1;
 				event.sender.send(IpcRendererMessages.IMPOSTOR_RADIO, false);
 			}


### PR DESCRIPTION
I'm not sure if there's a more efficient way to determine if the local player is impostor but this is what I could come up with.