### PR TITLE
Added a slider to adjust ghost volume for impostors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bettercrewlink",
-	"version": "3.0.5",
+	"version": "3.0.6",
 	"license": "GPL-3.0-or-later",
 	"description": "Free, open, Among Us Proximity Voice Chat",
 	"repository": {

--- a/src/common/ISettings.d.ts
+++ b/src/common/ISettings.d.ts
@@ -19,7 +19,8 @@ export interface ISettings {
 	meetingOverlay: boolean;
 
 	localLobbySettings: ILobbySettings;
-	ghostVolume: number;
+	ghostVolumeAsImpostor: number;
+	crewVolumeAsGhost: number;
 	masterVolume: number;
 	microphoneGain: number;
 	microphoneGainEnabled: boolean;

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -359,7 +359,7 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 						applyEffect(gain, reverb, destination, other);
 					}
 					collided = false;
-					endGain = 0.1;
+					endGain = settings.ghostVolumeAsImpostor / 100;
 				} else {
 					if (other.isDead && !me.isDead) {
 						endGain = 0;
@@ -1217,7 +1217,7 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 					gain = playerVolume === undefined ? gain : gain * playerVolume;
 
 					if (myPlayer.isDead && !player.isDead) {
-						gain = gain * (settings.ghostVolume / 100);
+						gain = gain * (settings.crewVolumeAsGhost / 100);
 					}
 					gain = gain * (settings.masterVolume / 100);
 				}

--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -754,20 +754,6 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 					<Divider />
 
 					<Typography id="input-slider" gutterBottom>
-						{t('settings.audio.crewvolume')}
-					</Typography>
-					<Grid container direction="row" justifyContent="center" alignItems="center">
-						<Grid item xs={11}>
-							<Slider
-								size="small"
-								value={settings.ghostVolume}
-								valueLabelDisplay="auto"
-								onChange={(_, newValue: number | number[]) => setSettings('ghostVolume', newValue as number)}
-								aria-labelledby="input-slider"
-							/>
-						</Grid>
-					</Grid>
-					<Typography id="input-slider" gutterBottom>
 						{t('settings.audio.mastervolume')}
 					</Typography>
 					<Grid container direction="row" justifyContent="center" alignItems="center">
@@ -778,6 +764,34 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 								valueLabelDisplay="auto"
 								max={200}
 								onChange={(_, newValue: number | number[]) => setSettings('masterVolume', newValue as number)}
+								aria-labelledby="input-slider"
+							/>
+						</Grid>
+					</Grid>
+					<Typography id="input-slider" gutterBottom>
+						{t('settings.audio.crewvolume')}
+					</Typography>
+					<Grid container direction="row" justifyContent="center" alignItems="center">
+						<Grid item xs={11}>
+							<Slider
+								size="small"
+								value={settings.crewVolumeAsGhost}
+								valueLabelDisplay="auto"
+								onChange={(_, newValue: number | number[]) => setSettings('crewVolumeAsGhost', newValue as number)}
+								aria-labelledby="input-slider"
+							/>
+						</Grid>
+					</Grid>
+					<Typography id="input-slider" gutterBottom>
+						{t('settings.audio.ghostvolumeasimpostor')}
+					</Typography>
+					<Grid container direction="row" justifyContent="center" alignItems="center">
+						<Grid item xs={11}>
+							<Slider
+								size="small"
+								value={settings.ghostVolumeAsImpostor}
+								valueLabelDisplay="auto"
+								onChange={(_, newValue: number | number[]) => setSettings('ghostVolumeAsImpostor', newValue as number)}
 								aria-labelledby="input-slider"
 							/>
 						</Grid>

--- a/src/renderer/settings/SettingsStore.tsx
+++ b/src/renderer/settings/SettingsStore.tsx
@@ -149,9 +149,13 @@ export const SettingsStore = new Store<ISettings>({
 			type: 'boolean',
 			default: true,
 		},
-		ghostVolume: {
+		crewVolumeAsGhost: {
 			type: 'number',
 			default: 100,
+		},
+		ghostVolumeAsImpostor: {
+			type: 'number',
+			default: 10,
 		},
 		masterVolume: {
 			type: 'number',

--- a/src/renderer/settings/SettingsStore.tsx
+++ b/src/renderer/settings/SettingsStore.tsx
@@ -88,6 +88,7 @@ export const SettingsStore = new Store<ISettings>({
 		},
 		'3.0.6': (store) => {
 			if (store.has('ghostVolume')) {
+				store.set('crewVolumeAsGhost', store.get('ghostVolume', 100));
 				// @ts-ignore
 				store.delete('ghostVolume');
 			}

--- a/src/renderer/settings/SettingsStore.tsx
+++ b/src/renderer/settings/SettingsStore.tsx
@@ -86,6 +86,12 @@ export const SettingsStore = new Store<ISettings>({
 				store.set('micSensitivityEnabled', false);
 			}
 		},
+		'3.0.6': (store) => {
+			if (store.has('ghostVolume')) {
+				// @ts-ignore
+				store.delete('ghostVolume');
+			}
+		}
 	},
 	schema: {
 		alwaysOnTop: {

--- a/static/locales/af/translation.json
+++ b/static/locales/af/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "If you set the sensitivity any lower it might not work.",
 			"mastervolume": "Master Volume",
 			"crewvolume": "Crew Volume as Ghost",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Test Speaker",
 			"test_speaker_stop": "Stop Test Speaker"
 		},

--- a/static/locales/ar/translation.json
+++ b/static/locales/ar/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "إذا قمت بتعيين حساسية أي أقل من ذلك قد لا تعمل.",
 			"mastervolume": "الصوت الرئيسي",
 			"crewvolume": "صوت الفريق كشبح",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "اختبار مكبر الصوت",
 			"test_speaker_stop": "إيقاف اختبار مكبر الصوت"
 		},

--- a/static/locales/az/translation.json
+++ b/static/locales/az/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Həssaslığı bir az da azaltsanız işləməyə bilər.",
 			"mastervolume": "Əsas Səs Həcmi",
 			"crewvolume": "Ruh kimi İşçi Səs Səviyyəsi",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Dinamiki test edin",
 			"test_speaker_stop": "Testi dayandırın"
 		},

--- a/static/locales/ca/translation.json
+++ b/static/locales/ca/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Si la sensibilitat és massa baixa potser no funciona",
 			"mastervolume": "Volum General",
 			"crewvolume": "Volum dels Companys com Fantasma",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Provar l'altaveu",
 			"test_speaker_stop": "Parar de Provar l'altaveu"
 		},

--- a/static/locales/cs/translation.json
+++ b/static/locales/cs/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Pokud nastavíte citlivost níže, mikrofon nemusí fungovat.",
 			"mastervolume": "Celková hlasitost",
 			"crewvolume": "Hlasitost živých když jsi duch",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Zkusit mikrofon",
 			"test_speaker_stop": "Zastavit zkoušku mikrofonu"
 		},

--- a/static/locales/da/translation.json
+++ b/static/locales/da/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "If you set the sensitivity any lower it might not work.",
 			"mastervolume": "Master Volume",
 			"crewvolume": "Crew Volume as Ghost",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Test Speaker",
 			"test_speaker_stop": "Stop Test Speaker"
 		},

--- a/static/locales/de/translation.json
+++ b/static/locales/de/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Falls die Empfindlichkeit zu niedrig eingestellt ist, kann es zu Problemen führen.",
 			"mastervolume": "Hauptlautstärke",
 			"crewvolume": "Crew-Lautstärke wenn tot",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Lautsprecher testen",
 			"test_speaker_stop": "Lautsprechertest stoppen"
 		},

--- a/static/locales/el/translation.json
+++ b/static/locales/el/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "If you set the sensitivity any lower it might not work.",
 			"mastervolume": "Master Volume",
 			"crewvolume": "Crew Volume as Ghost",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Test Speaker",
 			"test_speaker_stop": "Stop Test Speaker"
 		},

--- a/static/locales/en/translation.json
+++ b/static/locales/en/translation.json
@@ -53,7 +53,7 @@
 				"microphone_sens_warning": "If you set the sensitivity any lower it might not work.",
 				"mastervolume": "Master Volume",
 				"crewvolume": "Crew Volume as Ghost",
-				"ghostVolumeAsImpostor": "Ghost Volume as Impostor",
+				"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 				"test_speaker_start": "Test Speaker",
 				"test_speaker_stop": "Stop Test Speaker"
 			},

--- a/static/locales/en/translation.json
+++ b/static/locales/en/translation.json
@@ -53,6 +53,7 @@
 				"microphone_sens_warning": "If you set the sensitivity any lower it might not work.",
 				"mastervolume": "Master Volume",
 				"crewvolume": "Crew Volume as Ghost",
+				"ghostVolumeAsImpostor": "Ghost Volume as Impostor",
 				"test_speaker_start": "Test Speaker",
 				"test_speaker_stop": "Stop Test Speaker"
 			},

--- a/static/locales/eo/translation.json
+++ b/static/locales/eo/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Se vi plu malgrandigos la sentivecon, eble okazos problemoj.",
 			"mastervolume": "Ĝenerala laŭto",
 			"crewvolume": "Laŭto fantome",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Testi la laŭtparolilon",
 			"test_speaker_stop": "Ĉesi testi la laŭtparolilon"
 		},

--- a/static/locales/es/translation.json
+++ b/static/locales/es/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Si pones la sensibilidad más baja puede ser que no funcione.",
 			"mastervolume": "Volumen general",
 			"crewvolume": "Volumen de los Tripulantes como Fantasma",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Test de Altavoz",
 			"test_speaker_stop": "Parar Test de Altavoz"
 		},

--- a/static/locales/fa/translation.json
+++ b/static/locales/fa/translation.json
@@ -1,23 +1,23 @@
 {
 	"settings": {
-		"title": "Settings",
-		"language": "Language",
-		"warning": "Are you sure?",
+		"title": "تنظیمات",
+		"language": "زبان",
+		"warning": "آیا مطمئن هستید؟",
 		"lobbysettings": {
-			"title": "Lobby Settings",
-			"gamehostonly": "Only the game host can change this!",
-			"inlobbyonly": "You can only change this in the lobby!",
-			"voicedistance": "Voice Distance",
-			"voicedistance_impostor": "Impostor Voice Distance",
-			"wallsblockaudio": "Walls Block Audio",
-			"visiononly": "Hear People in Vision Only",
-			"impostorshearsghost": "Impostors Hear Dead",
-			"hear_imposters_invents": "Hear Impostors in Vents",
-			"private_talk_invents": "Private Talk in Vents",
-			"comms_sabotage_audio": "Comms Sabotage Disables Voice",
-			"hear_through_cameras": "Hear Through Cameras",
-			"ghost_only": "Only Ghosts can Talk/Hear",
-			"ghost_only_warning": "This disables the sound for alive players.",
+			"title": "ورودی تنظیمات",
+			"gamehostonly": "فقط میزبان بازی میتواند این را تغییر دهد!",
+			"inlobbyonly": "تو فقط میتوانی این را در ورودی تغییر دهی!",
+			"voicedistance": "فاصله ی صوتی",
+			"voicedistance_impostor": "ایمپوستر فاصله صوتی",
+			"wallsblockaudio": "دیوار بازدارنده ی صوتی",
+			"visiononly": "مردم را فقط در نگاه بشنوید",
+			"impostorshearsghost": "ایمپوستر صدای مرگ",
+			"hear_imposters_invents": "شیندن ایمپوستر از دریچه",
+			"private_talk_invents": "دریچه ی خصوصی صحبت کردن",
+			"comms_sabotage_audio": "خراب کردن رابطه ی صدای غیر فعال",
+			"hear_through_cameras": "شنیدن از طریق دوربین",
+			"ghost_only": "فقط روح میتواند صحبت کند\\بشنود",
+			"ghost_only_warning": "این صدا را برای پخش کننده های زنده غیر فعال میکند.",
 			"ghost_only_warning2": "Ghost can talk only enabled.",
 			"meetings_only": "Meetings/Lobby Only",
 			"meetings_only_warning": "This disables the sound for alive players outside meetings.",
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "If you set the sensitivity any lower it might not work.",
 			"mastervolume": "Master Volume",
 			"crewvolume": "Crew Volume as Ghost",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Test Speaker",
 			"test_speaker_stop": "Stop Test Speaker"
 		},
@@ -161,5 +162,5 @@
 		"microsoft": "Microsoft",
 		"custom": "Custom"
 	},
-	"translator_name": "Translator Name"
+	"translator_name": "Intancote"
 }

--- a/static/locales/fi/translation.json
+++ b/static/locales/fi/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "If you set the sensitivity any lower it might not work.",
 			"mastervolume": "Master Volume",
 			"crewvolume": "Crew Volume as Ghost",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Test Speaker",
 			"test_speaker_stop": "Stop Test Speaker"
 		},

--- a/static/locales/fr/translation.json
+++ b/static/locales/fr/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Si vous diminuez encore la sensibilité, cela pourrait ne pas fonctionner.",
 			"mastervolume": "Volume général",
 			"crewvolume": "Volume des survivants (en tant que fantôme)",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Tester la sortie audio",
 			"test_speaker_stop": "Arrêter le test"
 		},
@@ -95,13 +96,13 @@
 			"mobilehost": "Hôte pour mobile",
 			"vad_enabled": "VAD activée",
 			"hardware_acceleration": "Accélération Matérielle",
-			"hardware_acceleration_warning": "This disables Hardware Acceleration (which can increase CPU usage)",
+			"hardware_acceleration_warning": "Ceci désactive l'accélération matérielle (ce qui peut augmenter l'utilisation du processeur)",
 			"vad_enabled_warning": "Vous ne verrez pas qui parle si vous désactivez cette option.",
 			"echocancellation": "Annulation de l'écho",
 			"noiseSuppression": "Réducteur de bruit",
 			"spatial_audio": "Spatialisation sonore",
-			"oldsampledebug": "Samplerate Debug",
-			"oldsampledebug_warning": "This is a test function ONLY enabled when asked."
+			"oldsampledebug": "Débogage de la fréquence d'échantillonnage",
+			"oldsampledebug_warning": "Ceci est une fonction de test UNIQUEMENT activée lorsque demandée."
 		},
 		"streaming": {
 			"title": "Paramètres streaming",

--- a/static/locales/he/translation.json
+++ b/static/locales/he/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "If you set the sensitivity any lower it might not work.",
 			"mastervolume": "Master Volume",
 			"crewvolume": "Crew Volume as Ghost",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Test Speaker",
 			"test_speaker_stop": "Stop Test Speaker"
 		},

--- a/static/locales/hu/translation.json
+++ b/static/locales/hu/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Ha az érzékenységet lejjebb veszed akkor lehet hogy nem fog működni a mikrofon.",
 			"mastervolume": "Fő Hangerő",
 			"crewvolume": "Az emberek hangereje a szellemeknek",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Hangszóró tesztelése",
 			"test_speaker_stop": "Hangszóró tesztelésének leállítása"
 		},

--- a/static/locales/id/translation.json
+++ b/static/locales/id/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Jika Anda menyetel sensitivitas lebih rendah, itu mungkin tidak berfungsi.",
 			"mastervolume": "Volume Utama",
 			"crewvolume": "Volume Kru sebagai Hantu",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Uji Speaker",
 			"test_speaker_stop": "Hentikan Uji Speaker"
 		},

--- a/static/locales/it/translation.json
+++ b/static/locales/it/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Se imposta la sensibilità più bassa potrebbe non funzionare.",
 			"mastervolume": "Volume Generale",
 			"crewvolume": "Volume equipaggio come fantasma",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Prova Autoparlante",
 			"test_speaker_stop": "Ferma Prova Autoparlante"
 		},

--- a/static/locales/ja/translation.json
+++ b/static/locales/ja/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "これ以上、感度を下げるとうまくいかないかもしれません。",
 			"mastervolume": "マスターボリューム",
 			"crewvolume": "幽霊クルーの音量",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "スピーカーテスト",
 			"test_speaker_stop": "スピーカーテスト停止"
 		},

--- a/static/locales/ko/translation.json
+++ b/static/locales/ko/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "감도를 지나치게 낮게 설정하면 동작하지 않을 수 있습니다.",
 			"mastervolume": "마스터 음량",
 			"crewvolume": "유령 크루원의 음량",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "스피커 테스트",
 			"test_speaker_stop": "스피커 테스트 중지"
 		},

--- a/static/locales/nl/translation.json
+++ b/static/locales/nl/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Als je de gevoeligheid nog lager zet werkt het waarschijnlijk niet meer.",
 			"mastervolume": "Master Volume",
 			"crewvolume": "Crew volume als een geest.",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Test speaker",
 			"test_speaker_stop": "Stop Test Speaker"
 		},

--- a/static/locales/no/translation.json
+++ b/static/locales/no/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Hvis du angir følsomheten enda lavere, virker den kanskje ikke.",
 			"mastervolume": "Hovedvolum",
 			"crewvolume": "Crew-volum som spøkelse",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Test høyttaler",
 			"test_speaker_stop": "Stop testing av høyttaler"
 		},
@@ -95,13 +96,13 @@
 			"mobilehost": "Mobil vert",
 			"vad_enabled": "VAD aktivert",
 			"hardware_acceleration": "Maskinvareakselerasjon",
-			"hardware_acceleration_warning": "This disables Hardware Acceleration (which can increase CPU usage)",
+			"hardware_acceleration_warning": "Dette deaktiverer maskinvareakselerasjon (som kan øke CPU-bruk)",
 			"vad_enabled_warning": "Du vil ikke se hvem som snakker hvis deaktivert.",
 			"echocancellation": "Ekkodemping",
 			"noiseSuppression": "Støyreduksjon",
 			"spatial_audio": "Romslig lyd",
-			"oldsampledebug": "Samplerate Debug",
-			"oldsampledebug_warning": "This is a test function ONLY enabled when asked."
+			"oldsampledebug": "Feilsøk Samplerate",
+			"oldsampledebug_warning": "Dette er en testfunksjon, IKKE skru denne på med mindre du blir spurt."
 		},
 		"streaming": {
 			"title": "Strømningsinnstillinger",
@@ -122,10 +123,10 @@
 		"header": "Offentlige lobbyer",
 		"code": "Lobbykode",
 		"code_tooltips": {
-			"in_progress": "Game in Progress",
-			"full_lobby": "Lobby is Full",
-			"incompatible": "Incompatible Mods",
-			"and": "and"
+			"in_progress": "Spill pågår",
+			"full_lobby": "Lobbyen er full",
+			"incompatible": "Inkompatible mods",
+			"and": "og"
 		},
 		"list": {
 			"title": "Tittel",

--- a/static/locales/pl/translation.json
+++ b/static/locales/pl/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Jeśli ustawisz czułość niżej, mikrofon może nie działać.",
 			"mastervolume": "Głośność główna",
 			"crewvolume": "Głośność żywych graczy dla duchów",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Przetestuj dźwięk",
 			"test_speaker_stop": "Zatrzymaj test dźwięku"
 		},

--- a/static/locales/pt/translation.json
+++ b/static/locales/pt/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Ao baixar demasiado a sensibilidade, o microfone pode não funcionar.",
 			"mastervolume": "Volume Principal",
 			"crewvolume": "Volume dos Tripulantes como Fantasma",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Teste de Altifalante",
 			"test_speaker_stop": "Terminar o Teste"
 		},

--- a/static/locales/pt_BR/translation.json
+++ b/static/locales/pt_BR/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Se você definir a sensibilidade para um nível mais baixo, o microfone pode não funcionar.",
 			"mastervolume": "Volume Principal",
 			"crewvolume": "Volume da Tripulação como Fantasma",
+			"ghostvolumeasimpostor": "Volume do Fantasma como Impostor",
 			"test_speaker_start": "Iniciar o Teste de Alto-falante",
 			"test_speaker_stop": "Parar o Teste de Alto-falante"
 		},

--- a/static/locales/ro/translation.json
+++ b/static/locales/ro/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "If you set the sensitivity any lower it might not work.",
 			"mastervolume": "Master Volume",
 			"crewvolume": "Crew Volume as Ghost",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Test Speaker",
 			"test_speaker_stop": "Stop Test Speaker"
 		},

--- a/static/locales/ru/translation.json
+++ b/static/locales/ru/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Если выставить чувствительность ещё ниже, она может не сработать.",
 			"mastervolume": "Общая громкость",
 			"crewvolume": "Громкость экипажа для призрака",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Проверка динамика",
 			"test_speaker_stop": "Остановить проверку динамика"
 		},

--- a/static/locales/sk/translation.json
+++ b/static/locales/sk/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Ak nastavíš nižšiu citlivosť, nemusí to fungovať",
 			"mastervolume": "Celková hlasitosť",
 			"crewvolume": "Hlasitosť posádky keď si duch",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Test reproduktora",
 			"test_speaker_stop": "Zastaviť test reproduktora"
 		},

--- a/static/locales/sl/translation.json
+++ b/static/locales/sl/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Če nastavite občutljivost še nižje, morda ne bo več delovalo pravilno.",
 			"mastervolume": "Generalna jakost zvoka",
 			"crewvolume": "Glasnost živih igralcev, ko si duh",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Preizkusi zvočnike",
 			"test_speaker_stop": "Ustavi preizkus zvočnikov"
 		},

--- a/static/locales/sr/translation.json
+++ b/static/locales/sr/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "If you set the sensitivity any lower it might not work.",
 			"mastervolume": "Master Volume",
 			"crewvolume": "Crew Volume as Ghost",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Test Speaker",
 			"test_speaker_stop": "Stop Test Speaker"
 		},

--- a/static/locales/sv/translation.json
+++ b/static/locales/sv/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Om du ställer in känsligheten ännu lägre så kanske det inte fungerar.",
 			"mastervolume": "Huvudvolym",
 			"crewvolume": "Besättningens volym som spöke",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Testa högtalaren",
 			"test_speaker_stop": "Sluta Testa Högtalaren"
 		},

--- a/static/locales/tr/translation.json
+++ b/static/locales/tr/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Eğer hassasiyeti daha da azaltırsan çalışmayabilir.",
 			"mastervolume": "Ana Ses",
 			"crewvolume": "Hayaletken Crew Seviyesi",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Hoparlörü Test Et",
 			"test_speaker_stop": "Hoparlör Testini Durdur"
 		},

--- a/static/locales/tt/translation.json
+++ b/static/locales/tt/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Әгәр сизгерлекне бераз азрак куйсагыз, эшләмәскә мөмкин.",
 			"mastervolume": "Уртак тавыш",
 			"crewvolume": "Экипаж тавышы өрәкләр сыман",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Тавышны тикшерү",
 			"test_speaker_stop": "Тавышны тикшерүне туктату"
 		},

--- a/static/locales/uk/translation.json
+++ b/static/locales/uk/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "Якщо виставити чутливість ще нижче, вона може не спрацювати.",
 			"mastervolume": "Загальна гучність",
 			"crewvolume": "Гучність команди для привида",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Перевірка динаміка",
 			"test_speaker_stop": "Зупинити перевірку динаміка"
 		},

--- a/static/locales/vi/translation.json
+++ b/static/locales/vi/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "If you set the sensitivity any lower it might not work.",
 			"mastervolume": "Master Volume",
 			"crewvolume": "Crew Volume as Ghost",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "Test Speaker",
 			"test_speaker_stop": "Stop Test Speaker"
 		},

--- a/static/locales/zh_CN/translation.json
+++ b/static/locales/zh_CN/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "如果你设置灵敏度过低，可能导致麦克风无法正常工作。",
 			"mastervolume": "主音量",
 			"crewvolume": "作为幽灵时的船员音量",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "扬声器测试",
 			"test_speaker_stop": "停止扬声器测试"
 		},

--- a/static/locales/zh_TW/translation.json
+++ b/static/locales/zh_TW/translation.json
@@ -53,6 +53,7 @@
 			"microphone_sens_warning": "如果你設定的靈敏度過低，可能導致麥克風無法正常運作。",
 			"mastervolume": "主音量",
 			"crewvolume": "作為幽靈時的船員音量",
+			"ghostvolumeasimpostor": "Ghost Volume as Impostor",
 			"test_speaker_start": "喇叭測試",
 			"test_speaker_stop": "停止喇叭測試"
 		},


### PR DESCRIPTION
Also changed ambiguous "ghost volume" to "crew volume as ghost" to be more reflective of the actual usage and put master volume as the first slider rather than last.

@MatadorProBr I can't remember, do I need to be doing anything more for adding the translation string 'settings.audio.ghostvolumeasimpostor' besides putting it in the English file?