### PR TITLE
Impostor radio shortcut crashes BCL

### DIFF
--- a/src/main/hook.ts
+++ b/src/main/hook.ts
@@ -69,7 +69,7 @@ ipcMain.handle(IpcHandlerMessages.START_HOOK, async (event) => {
 			if (keyCodeMatches(pushToTalkShortcut!, keyId)) {
 				speaking += 1;
 			}
-			if (keyCodeMatches(impostorRadioShortcut!, keyId) && gameReader.lastState.players.find((value) => {return value.clientId === gameReader.lastState.clientId})?.isImpostor) {
+			if (keyCodeMatches(impostorRadioShortcut!, keyId) && gameReader.lastState.players?.find((value) => {return value.clientId === gameReader.lastState.clientId})?.isImpostor) {
 				speaking += 1;
 				event.sender.send(IpcRendererMessages.IMPOSTOR_RADIO, true);
 			}
@@ -93,7 +93,7 @@ ipcMain.handle(IpcHandlerMessages.START_HOOK, async (event) => {
 			if (keyCodeMatches(muteShortcut!, keyId)) {
 				event.sender.send(IpcRendererMessages.TOGGLE_MUTE);
 			}
-			if (keyCodeMatches(impostorRadioShortcut!, keyId) && gameReader.lastState.players.find((value) => {return value.clientId === gameReader.lastState.clientId})?.isImpostor) {
+			if (keyCodeMatches(impostorRadioShortcut!, keyId) && gameReader.lastState.players?.find((value) => {return value.clientId === gameReader.lastState.clientId})?.isImpostor) {
 				speaking -= 1;
 				event.sender.send(IpcRendererMessages.IMPOSTOR_RADIO, false);
 			}


### PR DESCRIPTION
 Impostor radio shortcut crashes BCL if Among Us hasn't been opened. The handler relies on `gameReader.lastState.players.find` and `players` is undefined which crashes the main thread on the `find`.