### PR TITLE
Added fix for longer names due to TMPro tags

### DIFF
--- a/src/main/GameReader.ts
+++ b/src/main/GameReader.ts
@@ -1083,7 +1083,7 @@ export default class GameReader {
 		let name = 'error';
 		let shiftedColor = -1;
 		if (data.hasOwnProperty('name')) {
-			name = this.readString(data.name).split(/<.*?>/).join('');
+			name = this.readString(data.name, 1000).split(/<.*?>/).join('');
 		} else {
 			this.readDictionary(data.outfitsPtr, 6, (k, v, i) => {
 				const key = this.readMemory<number>('int32', k);
@@ -1091,7 +1091,7 @@ export default class GameReader {
 				if (key === 0 && i == 0) {
 					const namePtr = this.readMemory<number>('pointer', val, this.offsets!.player.outfit.playerName); // 0x40
 					data.color = this.readMemory<number>('uint32', val, this.offsets!.player.outfit.colorId); // 0x14
-					name = this.readString(namePtr).split(/<.*?>/).join('');
+					name = this.readString(namePtr, 1000).split(/<.*?>/).join('');
 					data.hat = this.readString(this.readMemory<number>('ptr', val, this.offsets!.player.outfit.hatId));
 					data.skin = this.readString(this.readMemory<number>('ptr', val, this.offsets!.player.outfit.skinId));
 					data.visor = this.readString(this.readMemory<number>('ptr', val, this.offsets!.player.outfit.visorId));


### PR DESCRIPTION
So mods started using TMPro more heavily, making names MASSIVELY balloon in size passed the current default string length of 50.

Example:
```<color=#68192D>☆</color> <color=#722829>e</color><color=#803D23>u</color><color=#8E531D>r</color><color=#9C6818> </color><color=#AA7E12>m</color><color=#B8930C>o</color><color=#C6A907>m</color> <color=#D8C400>☆</color>```
This example is just a gradient on the name and has length of 218 but the mods appear to allow even more info/formatting so I figured 1k would be a safe bet for an upper bound.