### PR TITLE
Add "Ghosts can Talk Ingame" and "Grace Period" settings for Meetings/Lobby Only mode

### DIFF
--- a/src/common/ISettings.d.ts
+++ b/src/common/ISettings.d.ts
@@ -58,6 +58,8 @@ export interface ILobbySettings {
 	publicLobby_on: boolean;
 	publicLobby_title: string;
 	publicLobby_language: string;
+	ghostsCanTalkIngame: boolean;
+	gracePeriod: number;
 }
 
 export interface SocketConfig {

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -206,6 +206,8 @@ const defaultlocalLobbySettings: ILobbySettings = {
 	publicLobby_on: false,
 	publicLobby_title: '',
 	publicLobby_language: 'en',
+	ghostsCanTalkIngame: false,
+	gracePeriod: 0,
 };
 const radioOnAudio = new Audio();
 radioOnAudio.src = radioOnSound;
@@ -222,6 +224,7 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 	const settingsRef = useRef<ISettings>(settings);
 	const [lobbySettings, setHostLobbySettings] = useContext(HostSettingsContext);
 	const lobbySettingsRef = useRef(lobbySettings);
+	const gracePeriodRef = useRef<number>(0);
 	const maxDistanceRef = useRef(2);
 	const gameState = useContext(GameStateContext);
 	const playerColors = useContext(PlayerColorContext);
@@ -294,6 +297,7 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 		const { pan, gain, muffle, reverb, destination } = audio;
 		const audioContext = pan.context;
 		const useLightSource = true;
+		const lobbySettings = lobbySettingsRef.current;
 		let maxdistance = maxDistanceRef.current;
 		let panPos = [other.x - me.x, other.y - me.y];
 		let endGain = 0;
@@ -315,9 +319,25 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 			case GameState.TASKS:
 				endGain = 1;
 
-				if (lobbySettings.meetingGhostOnly) {
-					endGain = 0;
+				const gracePeriodMs = (lobbySettings.gracePeriod || 0) * 1000;
+				const isInGracePeriod = gracePeriodRef.current > 0 && Date.now() < gracePeriodRef.current + gracePeriodMs;
+
+				if (lobbySettings.meetingGhostOnly && lobbySettings.ghostsCanTalkIngame) {
+					if (me.isDead && other.isDead) {
+						panPos = [0, 0];
+						skipDistanceCheck = true;
+						endGain = 1;
+					} else {
+						if (!isInGracePeriod) {
+							endGain = 0;
+						}
+					}
+				} else if (lobbySettings.meetingGhostOnly) {
+					if (!isInGracePeriod) {
+						endGain = 0;
+					}
 				}
+
 				if (!me.isDead && lobbySettings.commsSabotage && state.comsSabotaged && !me.isImpostor) {
 					endGain = 0;
 				}
@@ -360,8 +380,8 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 					}
 					collided = false;
 					endGain = settings.ghostVolumeAsImpostor / 100;
-				} else {
-					if (other.isDead && !me.isDead) {
+				} else if (other.isDead && !me.isDead) {
+					if (!lobbySettings.meetingGhostOnly) {
 						endGain = 0;
 					}
 				}
@@ -369,8 +389,22 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 			case GameState.DISCUSSION:
 				panPos = [0, 0];
 				endGain = 1;
-				if (!me.isDead && other.isDead) {
-					endGain = 0;
+				
+				const gracePeriodMsDiscussion = (lobbySettings.gracePeriod || 0) * 1000;
+				const isInGracePeriodDiscussion = gracePeriodRef.current > 0 && Date.now() < gracePeriodRef.current + gracePeriodMsDiscussion;
+				
+				if (lobbySettings.meetingGhostOnly && lobbySettings.ghostsCanTalkIngame) {
+					if (!me.isDead && other.isDead) {
+						if (!isInGracePeriodDiscussion) {
+							endGain = 0;
+						}
+					}
+				} else {
+					if (!me.isDead && other.isDead) {
+						if (!isInGracePeriodDiscussion) {
+							endGain = 0;
+						}
+					}
 				}
 				break;
 
@@ -1268,6 +1302,25 @@ const Voice: React.FC<VoiceProps> = function ({ t, error: initialError }: VoiceP
 		if (myPlayer?.shiftedColor == -1 || !talking)
 			connectionStuff.current.socket?.emit('VAD', talking);
 	}, [talking])
+
+	useEffect(() => {
+		if (
+			lobbySettingsRef.current.meetingGhostOnly &&
+			lobbySettingsRef.current.gracePeriod > 0 &&
+			(gameState.gameState === GameState.TASKS || gameState.gameState === GameState.DISCUSSION) &&
+			(gameState.oldGameState === GameState.LOBBY || gameState.oldGameState === GameState.DISCUSSION || gameState.oldGameState === GameState.TASKS)
+		) {
+			if (
+				gameState.oldGameState === GameState.LOBBY ||
+				(gameState.oldGameState === GameState.DISCUSSION && gameState.gameState === GameState.TASKS) ||
+				(gameState.oldGameState === GameState.TASKS && gameState.gameState === GameState.DISCUSSION)
+			) {
+				gracePeriodRef.current = Date.now();
+			}
+		} else if (gameState.gameState === GameState.LOBBY || gameState.gameState === GameState.MENU) {
+			gracePeriodRef.current = 0;
+		}
+	}, [gameState.gameState, gameState.oldGameState]);
 
 	// Connect to P2P negotiator, when game mode change
 	useEffect(() => {

--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -603,7 +603,14 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 								openWarningDialog(
 									t('settings.warning'),
 									t('settings.lobbysettings.meetings_only_warning'),
-									() => updateLocalLobbySettingsBuffer({ meetingGhostOnly: newValue, deadOnly: false }),
+									() => {
+										updateLocalLobbySettingsBuffer({ 
+											meetingGhostOnly: newValue, 
+											deadOnly: false,
+											ghostsCanTalkIngame: newValue ? localLobbySettingsBuffer.ghostsCanTalkIngame : false,
+											gracePeriod: newValue ? localLobbySettingsBuffer.gracePeriod : 0
+										});
+									},
 									newValue
 								);
 							}}
@@ -611,6 +618,52 @@ const Settings: React.FC<SettingsProps> = function ({ t, open, onClose }: Settin
 							checked={canChangeLobbySettings ? localLobbySettingsBuffer.meetingGhostOnly : hostLobbySettings.meetingGhostOnly}
 							control={<Checkbox />}
 						/>
+					</DisabledTooltip>
+					<DisabledTooltip
+						disabled={!canChangeLobbySettings || !(canChangeLobbySettings ? localLobbySettingsBuffer.meetingGhostOnly : hostLobbySettings.meetingGhostOnly)}
+						title={
+							!canChangeLobbySettings
+								? isInMenuOrLobby
+									? t('settings.lobbysettings.gamehostonly')
+									: t('settings.lobbysettings.inlobbyonly')
+								: t('settings.lobbysettings.meetings_only_warning2')
+						}
+					>
+						<FormControlLabel
+							className={classes.formLabel}
+							label={t('settings.lobbysettings.ghosts_can_talk_ingame')}
+							disabled={!canChangeLobbySettings || !(canChangeLobbySettings ? localLobbySettingsBuffer.meetingGhostOnly : hostLobbySettings.meetingGhostOnly)}
+							onChange={(_, newValue: boolean) => updateLocalLobbySettingsBuffer({ ghostsCanTalkIngame: newValue })}
+							value={canChangeLobbySettings ? localLobbySettingsBuffer.ghostsCanTalkIngame : hostLobbySettings.ghostsCanTalkIngame}
+							checked={canChangeLobbySettings ? localLobbySettingsBuffer.ghostsCanTalkIngame : hostLobbySettings.ghostsCanTalkIngame}
+							control={<Checkbox />}
+						/>
+					</DisabledTooltip>
+					<DisabledTooltip
+						disabled={!canChangeLobbySettings || !(canChangeLobbySettings ? localLobbySettingsBuffer.meetingGhostOnly : hostLobbySettings.meetingGhostOnly)}
+						title={
+							!canChangeLobbySettings
+								? isInMenuOrLobby
+									? t('settings.lobbysettings.gamehostonly')
+									: t('settings.lobbysettings.inlobbyonly')
+								: t('settings.lobbysettings.meetings_only_warning2')
+						}
+					>
+						<div style={{ marginTop: 16 }}>
+							<Typography id="grace-period-slider" gutterBottom>
+								{t('settings.lobbysettings.grace_period')}: {canChangeLobbySettings ? localLobbySettingsBuffer.gracePeriod : hostLobbySettings.gracePeriod}s
+							</Typography>
+							<Slider
+								size="small"
+								disabled={!canChangeLobbySettings || !(canChangeLobbySettings ? localLobbySettingsBuffer.meetingGhostOnly : hostLobbySettings.meetingGhostOnly)}
+								value={canChangeLobbySettings ? localLobbySettingsBuffer.gracePeriod : hostLobbySettings.gracePeriod}
+								min={0}
+								max={10}
+								step={0.5}
+								onChange={(_, newValue: number | number[]) => updateLocalLobbySettingsBuffer({ gracePeriod: newValue as number })}
+								aria-labelledby="grace-period-slider"
+							/>
+						</div>
 					</DisabledTooltip>
 					{/* </FormGroup> */}
 				</div>

--- a/src/renderer/settings/SettingsStore.tsx
+++ b/src/renderer/settings/SettingsStore.tsx
@@ -305,6 +305,14 @@ export const SettingsStore = new Store<ISettings>({
 					type: 'string',
 					default: 'NONE',
 				},
+				ghostsCanTalkIngame: {
+					type: 'boolean',
+					default: false,
+				},
+				gracePeriod: {
+					type: 'number',
+					default: 0,
+				},
 			},
 			default: {
 				maxDistance: 5.32,
@@ -320,6 +328,8 @@ export const SettingsStore = new Store<ISettings>({
 				publicLobby_title: '',
 				publicLobby_language: 'en',
 				publicLobby_mods: 'NONE',
+				ghostsCanTalkIngame: false,
+				gracePeriod: 0,
 			},
 		},
 		launchPlatform: {

--- a/static/locales/en/translation.json
+++ b/static/locales/en/translation.json
@@ -21,7 +21,11 @@
 			"ghost_only_warning2": "Ghost can talk only enabled.",
 			"meetings_only": "Meetings/Lobby Only",
 			"meetings_only_warning": "This disables the sound for alive players outside meetings.",
-			"meetings_only_warning2": "Talking in meetings only enabled.",
+			"meetings_only_warning2": "Meetings/Lobby Only must be enabled to use this setting.",
+			"ghosts_can_talk_ingame": "Ghosts can Talk Ingame",
+			"ghosts_can_talk_ingame_description": "Allows ghosts to talk during the game. Ghosts can hear each other anywhere in the map (like meetings).",
+			"grace_period": "Grace Period",
+			"grace_period_description": "Delay before cutting off voices when the game/meeting starts (in seconds).",
 			"impostor_radio": "Impostor Radio",
 			"public_lobby": {
 				"change_settings": "Change Lobby Info",


### PR DESCRIPTION
Added two new lobby settings that enhance the "Meetings/Lobby Only" voice mode:

### 1. Ghosts can Talk Ingame
- **Requirement**: Can only be enabled when "Meetings/Lobby Only" is enabled
- **Functionality**:
  - Allows ghosts to talk and hear each other during the game (TASKS state)
  - Ghosts can hear each other anywhere on the map (distance-independent, like meetings)
  - Ghosts can hear alive players during grace period (if enabled)
  - In meetings, ghosts can hear both alive players and other ghosts

### 2. Grace Period
- **Requirement**: Can only be enabled when "Meetings/Lobby Only" is enabled
- **Functionality**:
  - Customizable delay (0-10 seconds, 0.5s increments) before voices are cut off
  - Applies when transitioning from LOBBY -> TASKS, LOBBY -> DISCUSSION, or between TASKS <-> DISCUSSION
  - Prevents abrupt voice cutoff when games/meetings start
  - Allows both hearing and talking during the grace period

_Note: I didn't add extra translations because I don't speak the languages. Sorry :C_